### PR TITLE
[BOP-96] Improve the install process

### DIFF
--- a/website/content/docs/install/_index.md
+++ b/website/content/docs/install/_index.md
@@ -13,11 +13,11 @@ Installing the latest version of Boundless is as simple as running the following
 ```shell
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/mirantis/boundless/main/script/install.sh)"
 ```
-The install script will download the latest version of the boundless cli, verify it with the checksum, and install it to /usr/local/bin/bctl.
+The install script will download the latest version of the boundless cli, verify it with the checksum, and install it to `/usr/local/bin/bctl`.
 
 #### Specific version
 
-If you would like to install a specific version of Boundless, you can specify the version as an argument to the install script:
+If you would like to install a specific version of Boundless, you can specify the version as an environment var for the install script:
 
 ```shell
 /bin/bash -c "VERSION=<desired version> $(curl -fsSL https://raw.githubusercontent.com/mirantis/boundless/main/script/install.sh)"
@@ -25,18 +25,16 @@ If you would like to install a specific version of Boundless, you can specify th
 
 You can find the different releases on the [releases page](https://github.com/Mirantis/boundless/releases).
 
-> Note: The
-
 ### Manual installation
 
-Open the [releases page](https://github.com/Mirantis/boundless/releases) and download the correct binary for your machine along with the boundless_<version>_checksums.txt file.
+Open the [releases page](https://github.com/Mirantis/boundless/releases) and download the correct binary for your machine along with the boundless_\<version\>_checksums.txt file.
 Place both in the same directory and run the following command:
 
 ```shell
 sha256sum -c boundless_<version>_checksums.txt --ignore-missing 2>/dev/null
 ```
 
-This will only print `OK` if atleast one of the files matches the checksums in the checksum file. Otherwise, it will return an error.
+This will only print `OK` if at least one of the files matches the checksums in the checksum file. Otherwise, it will return an error.
 
 Next you can install the binary on your system using the following `tar` command:
 

--- a/website/content/docs/install/_index.md
+++ b/website/content/docs/install/_index.md
@@ -6,26 +6,42 @@ weight: 1
 
 ### Installing using the script
 
+#### Latest
+
 Installing the latest version of Boundless is as simple as running the following command:
 
 ```shell
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/mirantis/boundless/main/script/install.sh)"
 ```
-This install script will download the latest version and install it on your system.
+The install script will download the latest version of the boundless cli, verify it with the checksum, and install it to /usr/local/bin/bctl.
 
-### Installing manually
+#### Specific version
 
-Open the [latest releases page](https://github.com/Mirantis/boundless/releases/latest) and download the correct binary for your machine along with the boundless_<version>_checksums.txt file.
+If you would like to install a specific version of Boundless, you can specify the version as an argument to the install script:
+
+```shell
+/bin/bash -c "VERSION=<desired version> $(curl -fsSL https://raw.githubusercontent.com/mirantis/boundless/main/script/install.sh)"
+```
+
+You can find the different releases on the [releases page](https://github.com/Mirantis/boundless/releases).
+
+> Note: The
+
+### Manual installation
+
+Open the [releases page](https://github.com/Mirantis/boundless/releases) and download the correct binary for your machine along with the boundless_<version>_checksums.txt file.
 Place both in the same directory and run the following command:
 
 ```shell
-sha256sum -c boundless_<version>_checksums.txt
+sha256sum -c boundless_<version>_checksums.txt --ignore-missing 2>/dev/null
 ```
 
-Look for the line that says "OK" with your correct binary name. Install the binary with the following command:
+This will only print `OK` if atleast one of the files matches the checksums in the checksum file. Otherwise, it will return an error.
+
+Next you can install the binary on your system using the following `tar` command:
 
 ```shell
-tar xvz -C /usr/local/bin/ -f bctl_<os>_<arch>.tar.gz
+tar xzf bctl_<os>_<arch>.tar.gz -C /usr/local/bin/
 ```
 
 ### Additional tools


### PR DESCRIPTION
https://mirantis.jira.com/browse/BOP-96

This makes it so the install script supports specifying a version and uses the checksum to verify the file. I also updated the docs to reflect this.

## Running Locally
The script will now look for a `VERSION` env file and install the specified version if it is defined. Otherwise it will default to the latest.

`VERSION=<desired version> install.sh`