### PR TITLE
[BOP-96] Fix install by checking which shasum is installed

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -63,7 +63,7 @@ elif command -v shasum &> /dev/null
 then
   shasum -a 256 -c ${CHECKSUM_NAME} --ignore-missing 2>/dev/null
 else
-  echo "Unable to verify checksum. Exiting without installing"
+  echo "Unable to find a shasum command installed. Exiting without installing"
   cleanup
   exit 1
 fi

--- a/script/install.sh
+++ b/script/install.sh
@@ -55,7 +55,19 @@ curl -sL ${CHECKSUM_URL} -O
 
 # Verify the checksum
 echo "Verifying checksum..."
-sha256sum -c ${CHECKSUM_NAME} --ignore-missing 2>/dev/null
+# Check shasum depending on which version of shasum is installed
+if command -v sha256sum &> /dev/null
+then
+  sha256sum -c ${CHECKSUM_NAME} --ignore-missing 2>/dev/null
+elif command -v shasum &> /dev/null
+then
+  shasum -a 256 -c ${CHECKSUM_NAME} --ignore-missing 2>/dev/null
+else
+  echo "Unable to verify checksum. Exiting without installing"
+  cleanup
+  exit 1
+fi
+
 if [[ $? -ne 0 ]]
 then
   echo "Checksum verification failed. Exiting without installing"

--- a/script/install.sh
+++ b/script/install.sh
@@ -71,7 +71,7 @@ fi
 if [[ $? -ne 0 ]]
 then
   echo "Checksum verification failed. Exiting without installing"
-  # cleanup
+  cleanup
   exit 1
 fi
 


### PR DESCRIPTION
This will check which shasum is installed during the install process so that the script works on multiple platforms. This is a followup to https://github.com/Mirantis/boundless/pull/7