### PR TITLE
Update the docs for changes in bctl regarding kubeconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 website/public/
 blueprint.yaml
 kubeconfig
+
+.idea

--- a/README.md
+++ b/README.md
@@ -44,17 +44,11 @@ It is currently possible to view and edit the documentation website locally. See
    ```shell
    bctl apply --config blueprint.yaml
    ```
-4. Connect to the cluster:
-   ```shell
-   export KUBECONFIG=./kubeconfig
-   kubectl get pods
-   ```
-   Note: `bctl` will create a `kubeconfig` file in the current directory.
    Use this file to connect to the cluster.
-5. Add wordpress addon to the `blueprint.yaml`:
+4. Add wordpress addon to the `blueprint.yaml`:
    ```YAML
    - name: wordpress
-     kind: HelmAddon
+     kind: helm
      enabled: true
      namespace: wordpress
      chart:
@@ -67,7 +61,7 @@ It is currently possible to view and edit the documentation website locally. See
    ```shell
    bctl update --config blueprint.yaml
    ```
-6. Delete the cluster:
+5. Delete the cluster:
    ```shell
    bctl reset --config blueprint.yaml
    ```
@@ -94,7 +88,7 @@ It is currently possible to view and edit the documentation website locally. See
     components:
       addons:
         - name: example-server
-          kind: HelmAddon
+          kind: helm
           enabled: true
           namespace: default
           chart:
@@ -177,22 +171,15 @@ Refer to the example TF scripts: https://github.com/Mirantis/boundless-cli/tree/
    ```shell
    bctl apply --config blueprint.yaml
    ```
-4. Connect to the cluster:
-   ```shell
-   export KUBECONFIG=./kubeconfig
-   kubectl get pods
-   ```
-   Note: `bctl` will create a `kubeconfig` file in the current directory.
-   Use this file to connect to the cluster.
-5. Update the cluster by modifying `blueprint.yaml` and then running:
+4. Update the cluster by modifying `blueprint.yaml` and then running:
    ```shell
    bctl update --config blueprint.yaml
    ```
-6. Delete the cluster:
+5. Delete the cluster:
    ```shell
    bctl reset --config blueprint.yaml
    ```
-7. Delete virtual machines:
+6. Delete virtual machines:
    ```bash
    cd example/aws-tf
    terraform destroy --auto-approve
@@ -227,7 +214,7 @@ spec:
    addons:
    - name: my-grafana
      enabled: true
-     kind: HelmAddon
+     kind: helm
      namespace: monitoring
      chart:
        name: grafana
@@ -264,7 +251,7 @@ spec:
               type: NodePort
     addons:
       - name: example-server
-        kind: HelmAddon
+        kind: helm
         enabled: true
         namespace: default
         chart:
@@ -316,7 +303,7 @@ spec:
                 type: NodePort
       addons:
         - name: example-server
-          kind: HelmAddon
+          kind: helm
           enabled: true
           namespace: default
           chart:

--- a/blueprints/lensappiq/README.md
+++ b/blueprints/lensappiq/README.md
@@ -9,7 +9,7 @@ This blueprint bootstraps a kind cluster and installs Lens AppIQ.
 ### Pre-req
 * [Install Boundless CLI `bctl`](https://github.com/Mirantis/boundless/blob/main/README.md#pre-requisite)
 
-### Bootsrap a Kind cluster with Lens AppIQ
+### Bootstrap a `Kind` cluster with Lens AppIQ
 
 ### Installation 
 
@@ -58,16 +58,15 @@ kubectl wait --namespace shipa-system \
                 --timeout=180s
 ```
 
-## Lens AppIQ on k0s Cluster
+## Lens AppIQ on `k0s` Cluster
 
 Bootstrap a k0s cluster and install Lens AppIQ.
-
 
 #### Pre-requisite
 
 * SSH Access to either one (single node) or two VMs (one controller and one worker)
 
-For AWS there are `terraform` scripts in the `example/` directory that can be used to create machines on AWS.
+**For AWS** there are `terraform` scripts in the `example/` directory that can be used to create machines on AWS.
 
 Refer to the example TF scripts: https://github.com/Mirantis/boundless-cli/tree/main/example/aws-tf
 
@@ -82,6 +81,8 @@ Refer to the example TF scripts: https://github.com/Mirantis/boundless-cli/tree/
 3. `terraform init`
 4. `terraform apply`
 5. `terraform output --raw bop_cluster > ./blueprint.yaml`
+
+**For installing using Lima VM**, start Lima VM by running `limactl start`. Refer [Lima documentation](https://github.com/lima-vm/lima#getting-started) for details
 
 #### Install blueprint on `k0s`
 
@@ -109,88 +110,73 @@ Refer to the example TF scripts: https://github.com/Mirantis/boundless-cli/tree/
            role: worker
    ```
    
-> For Single node configuration (such as when running for testing on Lima VM on Mac or a QEMU VM on linux), remove worker ssh entry and change `role: controller` to `role: single`
+   > For Single node configuration (such as when running for testing on Lima VM on Mac or a QEMU VM on linux), remove worker ssh entry and change `role: controller` to `role: single`
 
-2. Bootstrap k0s on provided VMs and install Lens AppIQ
+2. Bootstrap `k0s` on provided VMs and install Lens AppIQ
    Bootstrap a controller and worker k0s nodes and install Lens AppIQ: 
    ```shell
    bctl apply --config lensappiq-k0s-blueprint.yaml
    ```
-   Bootstrap a single node k0s cluster on Lima VM (Mac) and install Lens AppIQ
 
-> Start Lima VM by running `limactl start`. Refer [Lima documentation](https://github.com/lima-vm/lima#getting-started) for details 
+   It should print following output on your terminal:
 
    ```shell
-   lensappiq-k0s-lima-blueprint.yaml
-   ```   
-
-It should print following output on your terminal:
-
-```shell
-$ bctl apply -c lensappiq-k0s-lima-blueprint.yaml
-INFO[0000] Installing Kubernetes distribution: k0s      
-
-⠀⣿⣿⡇⠀⠀⢀⣴⣾⣿⠟⠁⢸⣿⣿⣿⣿⣿⣿⣿⡿⠛⠁⠀⢸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠀█████████ █████████ ███
-⠀⣿⣿⡇⣠⣶⣿⡿⠋⠀⠀⠀⢸⣿⡇⠀⠀⠀⣠⠀⠀⢀⣠⡆⢸⣿⣿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀███          ███    ███
-⠀⣿⣿⣿⣿⣟⠋⠀⠀⠀⠀⠀⢸⣿⡇⠀⢰⣾⣿⠀⠀⣿⣿⡇⢸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠀███          ███    ███
-⠀⣿⣿⡏⠻⣿⣷⣤⡀⠀⠀⠀⠸⠛⠁⠀⠸⠋⠁⠀⠀⣿⣿⡇⠈⠉⠉⠉⠉⠉⠉⠉⠉⢹⣿⣿⠀███          ███    ███
-⠀⣿⣿⡇⠀⠀⠙⢿⣿⣦⣀⠀⠀⠀⣠⣶⣶⣶⣶⣶⣶⣿⣿⡇⢰⣶⣶⣶⣶⣶⣶⣶⣶⣾⣿⣿⠀█████████    ███    ██████████
-k0sctl v0.16.0 Copyright 2023, k0sctl authors.
-Anonymized telemetry of usage will be sent to the authors.
-By continuing to use k0sctl you agree to these terms:
-https://k0sproject.io/licenses/eula
-INFO ==> Running phase: Connect to hosts 
-INFO [ssh] 127.0.0.1:60022: connected             
-INFO ==> Running phase: Detect host operating systems 
-INFO [ssh] 127.0.0.1:60022: is running Ubuntu 23.10 
-INFO ==> Running phase: Acquire exclusive host lock 
-INFO ==> Running phase: Prepare hosts    
-INFO ==> Running phase: Gather host facts 
-INFO [ssh] 127.0.0.1:60022: using lima-default as hostname 
-INFO [ssh] 127.0.0.1:60022: discovered eth0 as private interface 
-INFO [ssh] 127.0.0.1:60022: discovered 192.168.5.15 as private address 
-INFO ==> Running phase: Validate hosts   
-INFO ==> Running phase: Gather k0s facts 
-INFO ==> Running phase: Validate facts   
-INFO ==> Running phase: Download k0s on hosts 
-INFO [ssh] 127.0.0.1:60022: downloading k0s v1.28.3+k0s.0 
-INFO ==> Running phase: Install k0s binaries on hosts 
-INFO ==> Running phase: Configure k0s    
-WARN [ssh] 127.0.0.1:60022: generating default configuration 
-INFO [ssh] 127.0.0.1:60022: validating configuration 
-INFO [ssh] 127.0.0.1:60022: configuration was changed, installing new configuration 
-INFO ==> Running phase: Initialize the k0s cluster 
-INFO [ssh] 127.0.0.1:60022: installing k0s controller 
-INFO [ssh] 127.0.0.1:60022: waiting for the k0s service to start 
-INFO [ssh] 127.0.0.1:60022: waiting for kubernetes api to respond 
-INFO ==> Running phase: Release exclusive host lock 
-INFO ==> Running phase: Disconnect from hosts 
-INFO ==> Finished in 1m31s               
-INFO k0s cluster version v1.28.3+k0s.0 is now installed 
-INFO[0092] Waiting for nodes to be ready                
-INFO[0142] Installing Boundless Operator                
-INFO[0142] Waiting for all pods to be ready             
-INFO[0172] Applying Boundless Operator resource         
-INFO[0172] Applying Blueprint                           
-INFO[0172] Finished installing Boundless Operator       
-```
-
-> Wait for Lens AppIQ to come up
-```shell
-kubectl wait --namespace shipa-system \                             
-                --for=condition=ready pod \
-                --selector=app.kubernetes.io/managed-by=LensApps \
-                --timeout=180s
-```
-
-3. Connect to the cluster:
-   ```shell
-   export KUBECONFIG=./kubeconfig
-   kubectl get pods
+   $ bctl apply -c lensappiq-k0s-lima-blueprint.yaml
+   INFO[0000] Installing Kubernetes distribution: k0s      
+   
+   ⠀⣿⣿⡇⠀⠀⢀⣴⣾⣿⠟⠁⢸⣿⣿⣿⣿⣿⣿⣿⡿⠛⠁⠀⢸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠀█████████ █████████ ███
+   ⠀⣿⣿⡇⣠⣶⣿⡿⠋⠀⠀⠀⢸⣿⡇⠀⠀⠀⣠⠀⠀⢀⣠⡆⢸⣿⣿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀███          ███    ███
+   ⠀⣿⣿⣿⣿⣟⠋⠀⠀⠀⠀⠀⢸⣿⡇⠀⢰⣾⣿⠀⠀⣿⣿⡇⢸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠀███          ███    ███
+   ⠀⣿⣿⡏⠻⣿⣷⣤⡀⠀⠀⠀⠸⠛⠁⠀⠸⠋⠁⠀⠀⣿⣿⡇⠈⠉⠉⠉⠉⠉⠉⠉⠉⢹⣿⣿⠀███          ███    ███
+   ⠀⣿⣿⡇⠀⠀⠙⢿⣿⣦⣀⠀⠀⠀⣠⣶⣶⣶⣶⣶⣶⣿⣿⡇⢰⣶⣶⣶⣶⣶⣶⣶⣶⣾⣿⣿⠀█████████    ███    ██████████
+   k0sctl v0.16.0 Copyright 2023, k0sctl authors.
+   Anonymized telemetry of usage will be sent to the authors.
+   By continuing to use k0sctl you agree to these terms:
+   https://k0sproject.io/licenses/eula
+   INFO ==> Running phase: Connect to hosts 
+   INFO [ssh] 127.0.0.1:60022: connected             
+   INFO ==> Running phase: Detect host operating systems 
+   INFO [ssh] 127.0.0.1:60022: is running Ubuntu 23.10 
+   INFO ==> Running phase: Acquire exclusive host lock 
+   INFO ==> Running phase: Prepare hosts    
+   INFO ==> Running phase: Gather host facts 
+   INFO [ssh] 127.0.0.1:60022: using lima-default as hostname 
+   INFO [ssh] 127.0.0.1:60022: discovered eth0 as private interface 
+   INFO [ssh] 127.0.0.1:60022: discovered 192.168.5.15 as private address 
+   INFO ==> Running phase: Validate hosts   
+   INFO ==> Running phase: Gather k0s facts 
+   INFO ==> Running phase: Validate facts   
+   INFO ==> Running phase: Download k0s on hosts 
+   INFO [ssh] 127.0.0.1:60022: downloading k0s v1.28.3+k0s.0 
+   INFO ==> Running phase: Install k0s binaries on hosts 
+   INFO ==> Running phase: Configure k0s    
+   WARN [ssh] 127.0.0.1:60022: generating default configuration 
+   INFO [ssh] 127.0.0.1:60022: validating configuration 
+   INFO [ssh] 127.0.0.1:60022: configuration was changed, installing new configuration 
+   INFO ==> Running phase: Initialize the k0s cluster 
+   INFO [ssh] 127.0.0.1:60022: installing k0s controller 
+   INFO [ssh] 127.0.0.1:60022: waiting for the k0s service to start 
+   INFO [ssh] 127.0.0.1:60022: waiting for kubernetes api to respond 
+   INFO ==> Running phase: Release exclusive host lock 
+   INFO ==> Running phase: Disconnect from hosts 
+   INFO ==> Finished in 1m31s               
+   INFO k0s cluster version v1.28.3+k0s.0 is now installed 
+   INFO[0092] Waiting for nodes to be ready                
+   INFO[0142] Installing Boundless Operator                
+   INFO[0142] Waiting for all pods to be ready             
+   INFO[0172] Applying Boundless Operator resource         
+   INFO[0172] Applying Blueprint                           
+   INFO[0172] Finished installing Boundless Operator       
    ```
-   Note: `bctl` will create a `kubeconfig` file in the current directory.
-   Use this file to connect to the cluster.
+   > Note: `bctl apply` adds kube config context to default location and set it as the _current context_
 
+3. Wait for Lens AppIQ to come up
+   ```shell
+   kubectl wait --namespace shipa-system \                             
+                   --for=condition=ready pod \
+                   --selector=app.kubernetes.io/managed-by=LensApps \
+                   --timeout=180s
+   ```
 
 # Access Lens AppIQ
 ## Install Lens AppIQ CLI

--- a/blueprints/lensappiq/lensappiq-k0s-blueprint.yaml
+++ b/blueprints/lensappiq/lensappiq-k0s-blueprint.yaml
@@ -25,7 +25,7 @@ spec:
   components:
     addons:
       - name: lens-appiq
-        kind: HelmAddon
+        kind: helm
         enabled: true
         namespace: shipa-system
         chart:

--- a/blueprints/lensappiq/lensappiq-k0s-lima-blueprint.yaml
+++ b/blueprints/lensappiq/lensappiq-k0s-lima-blueprint.yaml
@@ -18,7 +18,7 @@ spec:
   components:
     addons:
       - name: lens-appiq
-        kind: HelmAddon
+        kind: helm
         enabled: true
         namespace: shipa-system
         chart:

--- a/blueprints/lensappiq/lensappiq-kind-blueprint.yaml
+++ b/blueprints/lensappiq/lensappiq-kind-blueprint.yaml
@@ -8,7 +8,7 @@ spec:
   components:
     addons:
       - name: lens-appiq
-        kind: HelmAddon
+        kind: helm
         enabled: true
         namespace: shipa-system
         chart:

--- a/deploy/static/boundless-operator.yaml
+++ b/deploy/static/boundless-operator.yaml
@@ -608,7 +608,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: ghcr.io/mirantis/boundless-operator:latest
+        image: ghcr.io/mirantis/boundless-operator:0.1.1-alpha
         livenessProbe:
           httpGet:
             path: /healthz

--- a/website/content/docs/blueprints/addons/helm.md
+++ b/website/content/docs/blueprints/addons/helm.md
@@ -14,7 +14,7 @@ spec:
     addons:
       - name: my-grafana
         enabled: true
-        kind: HelmAddon
+        kind: helm
         namespace: monitoring
         chart:
           name: grafana

--- a/website/content/docs/examples/bootstrap-k0s.md
+++ b/website/content/docs/examples/bootstrap-k0s.md
@@ -64,22 +64,16 @@ Refer to the example TF scripts: https://github.com/Mirantis/boundless-cli/tree/
    ```shell
    bctl apply --config blueprint.yaml
    ```
-4. Connect to the cluster:
-   ```shell
-   export KUBECONFIG=./kubeconfig
-   kubectl get pods
-   ```
-   Note: `bctl` will create a `kubeconfig` file in the current directory.
-   Use this file to connect to the cluster.
-5. Update the cluster by modifying `blueprint.yaml` and then running:
+   > Note: `bctl apply` adds kube config context to default location and set it as the _current context_
+4. Update the cluster by modifying `blueprint.yaml` and then running:
    ```shell
    bctl update --config blueprint.yaml
    ```
-6. Delete the cluster:
+5. Delete the cluster:
    ```shell
    bctl reset --config blueprint.yaml
    ```
-7. Delete virtual machines:
+6. Delete virtual machines:
    ```bash
    cd example/aws-tf
    terraform destroy --auto-approve

--- a/website/content/docs/examples/existing-cluster.md
+++ b/website/content/docs/examples/existing-cluster.md
@@ -24,7 +24,7 @@ weight: 3
     components:
       addons:
         - name: example-server
-          kind: HelmAddon
+          kind: helm
           enabled: true
           namespace: default
           chart:

--- a/website/content/docs/examples/k0s.md
+++ b/website/content/docs/examples/k0s.md
@@ -41,7 +41,7 @@ spec:
                 type: NodePort
       addons:
         - name: example-server
-          kind: HelmAddon
+          kind: helm
           enabled: true
           namespace: default
           chart:

--- a/website/content/docs/examples/kind.md
+++ b/website/content/docs/examples/kind.md
@@ -26,7 +26,7 @@ spec:
               type: NodePort
     addons:
       - name: example-server
-        kind: HelmAddon
+        kind: helm
         enabled: true
         namespace: default
         chart:

--- a/website/content/docs/examples/lens-app-iq-in-a-single-k0s.md
+++ b/website/content/docs/examples/lens-app-iq-in-a-single-k0s.md
@@ -68,23 +68,16 @@ INFO[0172] Applying Boundless Operator resource
 INFO[0172] Applying Blueprint
 INFO[0172] Finished installing Boundless Operator
 ```
+> Note: `bctl apply` adds kube config context to default location and set it as the _current context_
 
-> Wait for Lens AppIQ to come up
+
+Wait for Lens AppIQ to come up
 ```shell
 kubectl wait --namespace shipa-system \
                 --for=condition=ready pod \
                 --selector=app.kubernetes.io/managed-by=LensApps \
                 --timeout=180s
 ```
-
-3. Connect to the cluster:
-   ```shell
-   export KUBECONFIG=./kubeconfig
-   kubectl get pods
-   ```
-   Note: `bctl` will create a `kubeconfig` file in the current directory.
-   Use this file to connect to the cluster.
-
 
 # Access Lens AppIQ
 ## Install Lens AppIQ CLI

--- a/website/content/docs/getting-started/create.md
+++ b/website/content/docs/getting-started/create.md
@@ -11,22 +11,21 @@ Along with `boundless` CLI, you will also need the following tools:
 * [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) - required for installing a kind distribution
 
 #### Create a Kind cluster
-
 1. Generate a sample blueprint file:
-```shell
-bctl init --kind > blueprint.yaml
-```
-This will create a blueprints file `blueprint.yaml` with a kind cluster definition, a core ingress component and an addon.
+   ```shell
+   bctl init --kind > blueprint.yaml
+   ```
+   This will create a blueprints file `blueprint.yaml` with a kind cluster definition, a core ingress component and an addon.
 
 2. Deploy the blueprint
-```shell
-bctl apply --config blueprint.yaml
-```
-
+   ```shell
+   bctl apply --config blueprint.yaml
+   ```
+   
 3. Connect to the cluster:
-```shell
-export KUBECONFIG=${PWD}/kubeconfig
-kubectl cluster-info
-```
-> `bctl` will create a `kubeconfig` file in the current directory. Use this file to connect to the cluster.
+    ```shell
+    kubectl cluster-info
+    ```
+   > `bctl` will create a `kubeconfig` file in the current directory. Use this file to connect to the cluster.
+    
 

--- a/website/content/docs/getting-started/update.md
+++ b/website/content/docs/getting-started/update.md
@@ -7,41 +7,40 @@ weight: 2
 #### Update cluster
 
 1. Add a wordpress addon to the `blueprint.yaml`:
-```YAML
-- name: wordpress
-   kind: HelmAddon
-   enabled: true
-   namespace: wordpress
-   chart:
-      name: wordpress
-      repo: https://charts.bitnami.com/bitnami
-      version: 18.0.11
-```
+   ```YAML
+   - name: wordpress
+     kind: helm
+     enabled: true
+     namespace: wordpress
+     chart:
+       name: wordpress
+       repo: https://charts.bitnami.com/bitnami
+       version: 18.0.11
+   ```
 
 2. Update your cluster with the updated blueprint:
-
-```shell
-bctl update --config blueprint.yaml
-```
+   ```shell
+   bctl update --config blueprint.yaml
+   ```
 
 3. Verify that the wordpress addon is installed and running:
 
-```shell
-kubectl get pods --namespace wordpress
-```
+   ```shell
+   kubectl get pods --namespace wordpress
+   ```
 
-```shell
-NAME                           READY   STATUS      RESTARTS   AGE
-helm-install-wordpress-st8rh   0/1     Completed   0          2m58s
-wordpress-79d45fc94c-vg7n7     1/1     Running     0          2m49s
-wordpress-mariadb-0            1/1     Running     0          2m49s
-```
+   ```shell
+   NAME                           READY   STATUS      RESTARTS   AGE
+   helm-install-wordpress-st8rh   0/1     Completed   0          2m58s
+   wordpress-79d45fc94c-vg7n7     1/1     Running     0          2m49s
+   wordpress-mariadb-0            1/1     Running     0          2m49s
+   ```
 
 4. Connect to the wordpress page. You can forward requests to the server by running:
 
-```shell
-kubectl port-forward --namespace wordpress wordpress-79d45fc94c-vg7n7 8080:8080
-```
-> This command will need to be left running in the background. It does not return.
+   ```shell
+   kubectl port-forward --namespace wordpress wordpress-79d45fc94c-vg7n7 8080:8080
+   ```
+   > This command will need to be left running in the background. It does not return.
 
 You can then access the wordpress page at http://localhost:8080 in your browser.


### PR DESCRIPTION
`bctl` now support reading and writing kube config from the default locations:
1. explicit file with `--kubeconfig <path to kubeconfig file>` flag
2. from environment variable: `export KUBECONFIG=<path to kubeconfig file>`
3. default location: `~/.kube/config`

`bctl` also sets the cluster as the _current context_ in kubeconfig. This PR updates the steps to reflect these changes.