### PR TITLE
[BOP-178] doc changes to support manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ It is currently possible to view and edit the documentation website locally. See
 4. Add wordpress addon to the `blueprint.yaml`:
    ```YAML
    - name: wordpress
-     kind: helm
+     kind: chart
      enabled: true
      namespace: wordpress
      chart:
@@ -88,7 +88,7 @@ It is currently possible to view and edit the documentation website locally. See
     components:
       addons:
         - name: example-server
-          kind: helm
+          kind: chart
           enabled: true
           namespace: default
           chart:
@@ -214,7 +214,7 @@ spec:
    addons:
    - name: my-grafana
      enabled: true
-     kind: helm
+     kind: chart
      namespace: monitoring
      chart:
        name: grafana
@@ -251,7 +251,7 @@ spec:
               type: NodePort
     addons:
       - name: example-server
-        kind: helm
+        kind: chart
         enabled: true
         namespace: default
         chart:
@@ -303,7 +303,7 @@ spec:
                 type: NodePort
       addons:
         - name: example-server
-          kind: helm
+          kind: chart
           enabled: true
           namespace: default
           chart:

--- a/blueprints/lensappiq/lensappiq-k0s-blueprint.yaml
+++ b/blueprints/lensappiq/lensappiq-k0s-blueprint.yaml
@@ -25,7 +25,7 @@ spec:
   components:
     addons:
       - name: lens-appiq
-        kind: helm
+        kind: chart
         enabled: true
         namespace: shipa-system
         chart:

--- a/blueprints/lensappiq/lensappiq-k0s-lima-blueprint.yaml
+++ b/blueprints/lensappiq/lensappiq-k0s-lima-blueprint.yaml
@@ -18,7 +18,7 @@ spec:
   components:
     addons:
       - name: lens-appiq
-        kind: helm
+        kind: chart
         enabled: true
         namespace: shipa-system
         chart:

--- a/blueprints/lensappiq/lensappiq-kind-blueprint.yaml
+++ b/blueprints/lensappiq/lensappiq-kind-blueprint.yaml
@@ -8,7 +8,7 @@ spec:
   components:
     addons:
       - name: lens-appiq
-        kind: helm
+        kind: chart
         enabled: true
         namespace: shipa-system
         chart:

--- a/website/content/docs/blueprints/addons/helm.md
+++ b/website/content/docs/blueprints/addons/helm.md
@@ -14,7 +14,7 @@ spec:
     addons:
       - name: my-grafana
         enabled: true
-        kind: helm
+        kind: chart
         namespace: monitoring
         chart:
           name: grafana

--- a/website/content/docs/examples/existing-cluster.md
+++ b/website/content/docs/examples/existing-cluster.md
@@ -24,7 +24,7 @@ weight: 3
     components:
       addons:
         - name: example-server
-          kind: helm
+          kind: chart
           enabled: true
           namespace: default
           chart:

--- a/website/content/docs/examples/k0s.md
+++ b/website/content/docs/examples/k0s.md
@@ -41,7 +41,7 @@ spec:
                 type: NodePort
       addons:
         - name: example-server
-          kind: helm
+          kind: chart
           enabled: true
           namespace: default
           chart:

--- a/website/content/docs/examples/kind.md
+++ b/website/content/docs/examples/kind.md
@@ -26,7 +26,7 @@ spec:
               type: NodePort
     addons:
       - name: example-server
-        kind: helm
+        kind: chart
         enabled: true
         namespace: default
         chart:

--- a/website/content/docs/getting-started/update.md
+++ b/website/content/docs/getting-started/update.md
@@ -9,7 +9,7 @@ weight: 2
 1. Add a wordpress addon to the `blueprint.yaml`:
    ```YAML
    - name: wordpress
-     kind: helm
+     kind: chart
      enabled: true
      namespace: wordpress
      chart:


### PR DESCRIPTION
JIRA Ticket: https://mirantis.jira.com/browse/BOP-178

bctl now supports creating addons via manifest.

We can create AddOns via HelmCharts as well as Manifests. For this, you can specify the kind of addon you want to create in  the AddOnSpec. It can be set to either `manifest` or `chart`.

**AddOn with kind : chart**

```
addons:
      - name: my-grafana
        kind: chart
        enabled: true
        namespace: monitoring
        chart:
          name: grafana
          repo: https://grafana.github.io/helm-charts
          version: 6.58.7
          values: |
            ingress:
              enabled: true 
```

**AddOn with kind : manifest**

```
addons:
      - name: calico
        kind: manifest
        enabled: true
        namespace: boundless-system
        manifest:
          url: "https://raw.githubusercontent.com/projectcalico/calico/v3.26.3/manifests/calico.yaml" 
```