### PR TITLE
Created Makefile.ps1

### DIFF
--- a/Makefile.ps1
+++ b/Makefile.ps1
@@ -1,9 +1,39 @@
 # Makefile.ps1
+# Windows alternative to a makefile to allow easier editing of the hugo based documentation on Windows
+
+# Show help message
+function Show-Help {
+    Write-Output "help                  Show this help message",
+                 "install               Install bctl on your system",
+                 "docs                  Run the documentation website locally"
+}
+
+# Function to perform actions based on provided flag
+function Execute-Target {
+    param (
+        [string]$target
+    )
+
+    switch ($target) {
+        "install" {
+            Write-Output "Installing bctl on Windows not supported!"
+            #.\scripts\install.sh
+        }
+        "docs" {
+            hugo server --source website/ --disableFastRender
+        }
+        "help" {
+            Show-Help
+        }
+        default {
+            Write-Output "Unknown target: $target"
+        }
+    }
+}
 
 # Show help message
 if ($args.Count -eq 0) {
-    Write-Output "Insufficient option(s) provided!",
-                  "Should be: .\Makefile.ps1 [option]"
+    Show-Help
     exit
 }
 
@@ -11,16 +41,4 @@ if ($args.Count -eq 0) {
 $target = $args[0]
 
 # Execute targets
-switch ($target) {
-    "install" {
-        Write-Output "Installing bctl on Windows not supported!"
-        #.\scripts\install.ps1
-    }
-    "docs" {
-        Write-Output "Running the documentation website locally"
-        hugo server --source website/ --disableFastRender
-    }
-    default {
-        Write-Output "Unknown target: $target"
-    }
-}
+Execute-Target -target $target

--- a/Makefile.ps1
+++ b/Makefile.ps1
@@ -1,0 +1,26 @@
+# Makefile.ps1
+
+# Show help message
+if ($args.Count -eq 0) {
+    Write-Output "Insufficient option(s) provided!",
+                  "Should be: .\Makefile.ps1 [option]"
+    exit
+}
+
+# Parse command line arguments
+$target = $args[0]
+
+# Execute targets
+switch ($target) {
+    "install" {
+        Write-Output "Installing bctl on Windows not supported!"
+        #.\scripts\install.ps1
+    }
+    "docs" {
+        Write-Output "Running the documentation website locally"
+        hugo server --source website/ --disableFastRender
+    }
+    default {
+        Write-Output "Unknown target: $target"
+    }
+}


### PR DESCRIPTION
Created an initial version of the Makefile script for Windows Powershell. Kept it simple and added the options to handle:
1) no options provided
2) install flag provided (does nothing so far)
3) docs flag provided (actually runs the hugo server on Windows)
4) invalid flags provided

Sample Outputs:
```
PS C:\Users\mhowlader\Documents\GitHub\windows_makefile_1> .\Makefile.ps1     
Insufficient option(s) provided!
Should be: .\Makefile.ps1 [option]
PS C:\Users\mhowlader\Documents\GitHub\windows_makefile_1> .\Makefile.ps1 docs
Running the documentation website locally
Watching for changes in C:\Users\mhowlader\Documents\GitHub\windows_makefile_1\website\{archetypes,content,i18n,static}
Watching for config changes in C:\Users\mhowlader\Documents\GitHub\windows_makefile_1\website\hugo.yaml, C:\Users\mhowlader\Documents\GitHub\windows_makefile_1\website\go.mod
ended windows/amd64 BuildDate=2023-12-05T15:22:31Z VendorInfo=gohugoio


                   | EN
-------------------+-----
  Pages            | 34
  Paginator pages  |  0
  Non-page files   |  0
  Static files     | 11
  Processed images |  0
  Aliases          |  0
  Sitemaps         |  1
  Cleaned          |  0

Built in 122 ms
Environment: "development"
Serving pages from memory
Web Server is available at //localhost:1313/ (bind address 127.0.0.1)
Press Ctrl+C to stop
```