### PR TITLE
[BOP-100] Add a page for each command

### DIFF
--- a/website/content/docs/bctl-reference/_index.md
+++ b/website/content/docs/bctl-reference/_index.md
@@ -4,9 +4,8 @@ draft: false
 weight: 5
 ---
 
-- Install the Boundless CLI binary:
-```shell
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/mirantiscontainers/boundless/main/script/install.sh)"
-```
+`bctl` is a command line tool for creating and managing Boundless clusters. It makes interacting with Boundless clusters easy and intuitive.
 
+If you haven't installed `bctl` yet, see the [installation](/docs/install) page.
 
+This section provides details of the various `bctl` commands and their usage.

--- a/website/content/docs/bctl-reference/apply.md
+++ b/website/content/docs/bctl-reference/apply.md
@@ -1,0 +1,21 @@
+---
+title: "apply"
+draft: false
+weight: 5
+---
+
+`bctl apply` is used to apply a configuration to a cluster. It is used to create the underlying cluster, install the `boundless-operator`, and install the designated boundless addons.
+
+## Usage
+
+```bash
+bctl apply [flags]
+```
+
+## Flags
+
+| Flag | Description | Default |
+| ---- | ----------- | ------- |
+| `-h, --help` | Display the help for apply |
+| `-f, --file` | The path to the blueprint file to apply | `./boundless.yaml` |
+| `operator-uri` | The URL or path of the boundless-operator manifest to use | `https://raw.githubusercontent.com/mirantiscontainers/boundless/main/deploy/static/boundless-operator.yaml` |

--- a/website/content/docs/bctl-reference/init.md
+++ b/website/content/docs/bctl-reference/init.md
@@ -1,0 +1,21 @@
+---
+title: "init"
+draft: false
+weight: 5
+---
+
+`bctl init` is used to initialize a blueprint file. By default, it will print the blueprint to stdout. This can be redirected to a file for later use. By default, this blueprint will be for a k0s cluster.
+
+## Usage
+
+```bash
+bctl init [flags]
+bctl init [flags] > blueprint.yaml
+```
+
+## Flags
+
+| Flag | Description | Default |
+| ---- | ----------- | ------- |
+| `-h, --help` | Display the help for init |
+| `--kind` | Creates a blueprint that uses a kind cluster | `false` |

--- a/website/content/docs/bctl-reference/reset.md
+++ b/website/content/docs/bctl-reference/reset.md
@@ -1,0 +1,20 @@
+---
+title: "reset"
+draft: false
+weight: 5
+---
+
+`bctl reset` is used to reset a cluster. It is used to remove the underlying cluster, uninstall the `boundless-operator`, and uninstall the designated boundless addons.
+
+## Usage
+
+```bash
+bctl reset [flags]
+```
+
+## Flags
+
+| Flag | Description | Default |
+| ---- | ----------- | ------- |
+| `-h, --help` | Display the help for reset |
+| `-f, --file` | The path to the blueprint file to reset | `./boundless.yaml` |

--- a/website/content/docs/bctl-reference/status.md
+++ b/website/content/docs/bctl-reference/status.md
@@ -1,0 +1,21 @@
+---
+title: "status"
+draft: false
+weight: 5
+---
+
+`bctl status` is used to get the status of a blueprint. It will check if the designated components are available.
+
+## Usage
+
+```bash
+bctl status [flags]
+```
+
+## Flags
+
+| Flag | Description | Default |
+| ---- | ----------- | ------- |
+| `-h, --help` | Display the help for status |
+| `-f, --file` | The path to the blueprint file to check the status of | `./boundless.yaml` |
+| `operator-uri` | The URL or path of the boundless-operator manifest to use | `https://raw.githubusercontent.com/mirantiscontainers/boundless/main/deploy/static/boundless-operator.yaml` |

--- a/website/content/docs/bctl-reference/update.md
+++ b/website/content/docs/bctl-reference/update.md
@@ -1,0 +1,20 @@
+---
+title: "update"
+draft: false
+weight: 5
+---
+
+`bctl update` is used to update a cluster. It is used to update the underlying cluster, update the `boundless-operator`, and update the designated boundless addons according to the provided blueprint.
+
+## Usage
+
+```bash
+bctl update [flags]
+```
+
+## Flags
+
+| Flag | Description | Default |
+| ---- | ----------- | ------- |
+| `-h, --help` | Display the help for update |
+| `-f, --file` | The path to the blueprint file to use for the update | `./boundless.yaml` |

--- a/website/content/docs/bctl-reference/upgrade.md
+++ b/website/content/docs/bctl-reference/upgrade.md
@@ -1,0 +1,21 @@
+---
+title: "upgrade"
+draft: false
+weight: 5
+---
+
+`bctl upgrade` is used to upgrade the boundless operator on a cluster.
+
+## Usage
+
+```bash
+bctl upgrade [flags]
+```
+
+## Flags
+
+| Flag | Description | Default |
+| ---- | ----------- | ------- |
+| `-h, --help` | Display the help for update |
+| `-f, --file` | The path to the blueprint file to use for the upgrade | `./boundless.yaml` |
+| `operator-uri` | The URL or path of the boundless-operator manifest to use | `https://raw.githubusercontent.com/mirantiscontainers/boundless/main/deploy/static/boundless-operator.yaml` |

--- a/website/content/docs/bctl-reference/version.md
+++ b/website/content/docs/bctl-reference/version.md
@@ -1,0 +1,20 @@
+---
+title: "version"
+draft: false
+weight: 5
+---
+
+`bctl version` is used to get the version of the boundless CLI.
+
+## Usage
+
+```bash
+bctl version [flags]
+```
+
+## Flags
+
+| Flag | Description | Default |
+| ---- | ----------- | ------- |
+| `-h, --help` | Display the help for update |
+| `--short` | Display version in short format | `false` |


### PR DESCRIPTION
https://mirantis.jira.com/browse/BOP-100

This adds a basic page for each of the bctl command so it is no longer an empty section in the docs