### PR TITLE
Add a directory permission check in install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,6 +2,16 @@
 INSTALL_DIR=/usr/local/bin
 REPO_URL="https://github.com/mirantiscontainers/boundless"
 
+# Check if there is sufficient permission for the binary download to succeed later in the script
+touch testfile
+if [[ $? -ne 0 ]]
+then
+  echo "Unable to write to directory: $(pwd)"
+  echo "Change to a directory with sufficient permissions and retry."
+  exit 1
+fi
+rm testfile
+
 # Determine the version
 if [[ ! -n $VERSION ]]
 then


### PR DESCRIPTION
When I was trying the suggested curl command for bctl binary installation using the `install.sh` script, I ran into the following issue:
```
/usr/local/bin$ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/mirantiscontainers/boundless/main/scripts/install.sh)"
VERSION not set, using latest release: v0.1.2
Downloading https://github.com/mirantiscontainers/boundless/releases/download/v0.1.2/bctl_linux_x86_64.tar.gz
Downloading binary failed. Exiting without installing
```
After some troubleshooting, it looks to be that running `install.sh` from a system directory like `/usr/local/bin` will result in a permission error. Where as a common directory like `~/Downloads` works just fine. The error message was a bit confusing, so to assist users, a basic check for this in the script may be helpful.

Testing done (note `install_original.sh` and `install_updated_dir_check.sh` to compare change in behavior):
Happy path, no change in behaviour.
```
~/Documents/Github/boundless/scripts$ ls -latr
total 16
drwxrwxr-x 9 moshiur moshiur 4096 Jan 16 15:32 ..
-rwxrwxr-x 1 moshiur moshiur 2500 Jan 16 15:40 install_original.sh
-rwxrwxr-x 1 moshiur moshiur 2750 Jan 16 15:42 install_updated_dir_check.sh
drwxrwxr-x 2 moshiur moshiur 4096 Jan 16 15:42 .
~/Documents/Github/boundless/scripts$ ./install_original.sh
VERSION not set, using latest release: v0.1.2
Downloading https://github.com/mirantiscontainers/boundless/releases/download/v0.1.2/bctl_linux_x86_64.tar.gz
Downloading https://github.com/mirantiscontainers/boundless/releases/download/v0.1.2/boundless_0.1.2_checksums.txt...
Verifying checksum...
bctl_linux_x86_64.tar.gz: OK
bctl installed to /usr/local/bin
~/Documents/Github/boundless/scripts$ ./install_updated_dir_check.sh
VERSION not set, using latest release: v0.1.2
Downloading https://github.com/mirantiscontainers/boundless/releases/download/v0.1.2/bctl_linux_x86_64.tar.gz
Downloading https://github.com/mirantiscontainers/boundless/releases/download/v0.1.2/boundless_0.1.2_checksums.txt...
Verifying checksum...
bctl_linux_x86_64.tar.gz: OK
bctl installed to /usr/local/bin
```

Copy over the scripts to a system directory:
```
~/Documents/Github/boundless/scripts$ cp ./install_* /usr/local/bin/
cp: cannot create regular file '/usr/local/bin/install_original.sh': Permission denied
cp: cannot create regular file '/usr/local/bin/install_updated_dir_check.sh': Permission denied
~/Documents/Github/boundless/scripts$ sudo cp ./install_* /usr/local/bin/
~/Documents/Github/boundless/scripts$ cd /usr/local/bin/
```
Run the install script from a system directory:
```
/usr/local/bin$ ls -la ./install_*
-rwxr-xr-x 1 root root 2500 Jan 16 15:45 ./install_original.sh
-rwxr-xr-x 1 root root 2750 Jan 16 15:45 ./install_updated_dir_check.sh
/usr/local/bin$ ./install_original.sh
VERSION not set, using latest release: v0.1.2
Downloading https://github.com/mirantiscontainers/boundless/releases/download/v0.1.2/bctl_linux_x86_64.tar.gz
Downloading binary failed. Exiting without installing
/usr/local/bin$ ./install_updated_dir_check.sh
touch: cannot touch 'testfile': Permission denied
Unable to write to directory: /usr/local/bin
Change to a directory with sufficient permissions and retry.
```
With the newest changes to `install.sh`, it explicitly tells the user to run the script from a directory with sufficient permission.