### PR TITLE
Update k0s-example.yaml

### DIFF
--- a/blueprints/k0s-example/k0s-example.yaml
+++ b/blueprints/k0s-example/k0s-example.yaml
@@ -5,12 +5,13 @@ metadata:
 spec:
   kubernetes:
     provider: k0s
-    version: v1.28.3+k0s.0
+    version: 1.28.3+k0s.0
     infra:
       hosts:
       - localhost:
           enabled: true
         role: single
+  components:
     addons:
       - name: example-server
         kind: chart


### PR DESCRIPTION
Added `components:` section and removed the letter `v` from version (now it's 1.28.3+k0s.0).

Tested the new yaml file on my Ubuntu setup and worked fine.