### PR TITLE
Pass secrets to the docs workflow

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -2,8 +2,9 @@ name: Release
 
 on:
   release:
-    types: [created,prereleased,released,published]
+    types: [created, prereleased, released, published]
 
 jobs:
   docs:
     uses: ./.github/workflows/docs.yml
+    secrets: inherit


### PR DESCRIPTION
CI failed when the doc publish was triggered by CI. https://github.com/MirantisContainers/boundless/actions/runs/7647155385

This adds the line to pass the secrets to the called workflows.