### PR TITLE
[BOP-264] Update metallb url to the correct one

### DIFF
--- a/website/content/docs/blueprint-reference/components.md
+++ b/website/content/docs/blueprint-reference/components.md
@@ -95,7 +95,7 @@ spec:
         kind: manifest
         enabled: true
         manifest:
-          url: "https://raw.githubusercontent.com/metallb/metallb/v0.13.10/config/manifests/metallb-native.yaml"
+          url: "https://raw.githubusercontent.com/metallb/metallb/v0.14.3/config/manifests/metallb-native.yaml"
 ```
 
 | Field        |               Description               |

--- a/website/content/docs/blueprint-reference/components.md
+++ b/website/content/docs/blueprint-reference/components.md
@@ -95,7 +95,7 @@ spec:
         kind: manifest
         enabled: true
         manifest:
-          url: "https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/admin/namespace-dev.yaml"
+          url: "https://raw.githubusercontent.com/metallb/metallb/v0.13.10/config/manifests/metallb-native.yaml"
 ```
 
 | Field        |               Description               |


### PR DESCRIPTION
## JIRA Ticket 
https://mirantis.jira.com/browse/BOP-264

This PR updates the url used for Metallb Addon. In the older version, it used a link to the manifest that creates namespace instead of metallb.

As a result, the user don't see the MetalLb pods even though they expect it to be there.