### PR TITLE
[BOP-272] Add a blueprint reference that uses both manifest and helm chart addons

### DIFF
--- a/website/content/docs/blueprint-reference/components.md
+++ b/website/content/docs/blueprint-reference/components.md
@@ -42,8 +42,9 @@ Core components are components that are typically required for a cluster to func
 
 ## Addons
 
-Addons allow you to easily install new software on your cluster. They are defined as an array in the `spec.components.addons` section of a blueprint.
-There are two types of addons: [Helm Charts](#helm-charts) and [Manifests](#manifests).
+Addons allow you to easily install new software on your cluster. There are two types of addons: [Helm Charts](#helm-charts) and [Manifests](#manifests). 
+They are defined as an array in the `spec.components.addons` section of a blueprint. Please refer to this [example](#example) that uses both of these types in addons section.
+
 
 | Field     |                            Description                            |
 | :-------- | :---------------------------------------------------------------: |
@@ -95,10 +96,36 @@ spec:
         kind: manifest
         enabled: true
         manifest:
-          url: "https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/admin/namespace-dev.yaml"
+          url: "https://raw.githubusercontent.com/metallb/metallb/v0.14.3/config/manifests/metallb-native.yaml"
 ```
 
 | Field        |               Description               |
 | :----------- | :-------------------------------------: |
 | manifest     |      Used to specify manifest info      |
 | manifest.url | Used to specify the url of the manifest |
+
+### Example
+
+An example blueprint that uses both [Helm Charts](#helm-charts) and [Manifests](#manifests) in addons section.
+
+```yaml
+spec:
+  components:
+    addons:
+      - name: my-grafana
+        enabled: true
+        kind: chart
+        namespace: monitoring
+        chart:
+          name: grafana
+          repo: https://grafana.github.io/helm-charts
+          version: 6.58.7
+          values: |
+            ingress:
+              enabled: true
+      - name: metallb
+        kind: manifest
+        enabled: true
+        manifest:
+          url: "https://raw.githubusercontent.com/metallb/metallb/v0.14.3/config/manifests/metallb-native.yaml"
+```


### PR DESCRIPTION
## JIRA ticket

https://mirantis.jira.com/browse/BOP-272

## Description

Currently, we don't have any explicit example in our docs that explains how to use both of the types of addons - `manifest` and `helmchart` under `AddOn` section in the blueprint.
As a result, the user ends up copying the examples and comes up with the following blueprint with the multiple instances of Addons. And they don't see the expected results.

```
apiVersion: boundless.mirantis.com/v1alpha1
kind: Blueprint
metadata:
  name: bop-cluster
spec:
  kubernetes:
    provider: k0s
    version: 1.27.4+k0s.0
 components:
    addons:
      - name: example-server
        kind: chart
        enabled: true
        namespace: default
        chart:
          name: nginx
          repo: https://charts.bitnami.com/bitnami
          version: 15.1.1
          values: |2
            "service":
              "type": "ClusterIP"
    addons:
      - name: my-grafana
        enabled: true
        kind: chart
        namespace: monitoring
        chart:
          name: grafana
          repo: https://grafana.github.io/helm-charts
          version: 6.58.7
          values: |
           ingress:
             enabled: true
```

## Solution 
This PR adds a reference example that clarifies how to specify both kinds of Addons in the blueprint. Hopefully, it makes it clearer.

