### PR TITLE
[BOP-313] Add documentation for manifest kustomize support

### DIFF
--- a/website/content/docs/blueprint-reference/components.md
+++ b/website/content/docs/blueprint-reference/components.md
@@ -173,6 +173,8 @@ The following example updates the `failureThreshold` of the metallb controller c
                     failureThreshold: 2
 ```
 
+For more examples, please refer to [Kustomize - Inline Patches](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/inlinePatch.md)
+
 ### Images
 
 To replace the name of an image in the manifest, the user must specify the image `name`(that is to be replaced), the `new name` and the `new tag`.

--- a/website/content/docs/blueprint-reference/components.md
+++ b/website/content/docs/blueprint-reference/components.md
@@ -134,7 +134,12 @@ spec:
 
 ### Kustomize Manifest based addons
 
-The users can now apply customizations on top of the url based manifests. They can specify `inline patches` and keyword-based `images` kustomization in the blueprint. The boundless controller applies these kustomize transformations on the manifest objects and deploys them in the cluster.
+The users can now customize the static resources for URL based Manifest addons. These customization are based on [Kustomize](https://kustomize.io/).
+
+Following kustomize primitives are currently supported:
+
+- [Built-in images transformer](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/transformerconfigs/README.md#images-transformer).
+- [Inline patches](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/inlinePatch.md)
 
 The inline patches and images are specified under the field, `values`, in the manifest spec. Please refer to this [example](#manifest-addon-kustomization) that uses both inline patches and images in the manifest addon.
 


### PR DESCRIPTION
This PR adds documentation for kustomize support introduced for manifest based addons.
JIRA Ticket: https://mirantis.jira.com/browse/BOP-313