### PR TITLE
[BOP-342] Add reference for kubeconfig command in bctl

### DIFF
--- a/website/content/docs/bctl-reference/kubeconfig.md
+++ b/website/content/docs/bctl-reference/kubeconfig.md
@@ -1,0 +1,20 @@
+---
+title: "kubeconfig"
+draft: false
+weight: 5
+---
+
+`bctl kubeconfig` is used to generate kubeconfig file for the current Blueprint. This command prints the kubeconfig for the underlying cluster specified in the current blueprint. 
+
+## Usage
+
+```bash
+bctl kubeconfig [flags]
+```
+
+## Flags
+
+| Flag | Description                                                        | Default |
+| ---- |--------------------------------------------------------------------| ------- |
+| `-h, --help` | Display the help for kubeconfig                                    |
+| `-f, --file` | The path to the current blueprint file used to generate kubeconfig | `./boundless.yaml` |


### PR DESCRIPTION
### JIRA Ticket

https://mirantis.jira.com/browse/BOP-342

### Description
This ticket adds reference for the new kubeconfig command in bctl docs.