### PR TITLE
Add token for release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,18 +7,6 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
-
 # Default to bash
 defaults:
   run:
@@ -56,6 +44,8 @@ jobs:
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
       - name: Upload artifact
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_CI_BOUNDLESS }}
         uses: actions/upload-pages-artifact@v2
         with:
           path: ./website/public
@@ -64,6 +54,8 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.PAT_CI_BOUNDLESS }}
     runs-on: ubuntu-latest
     needs: build
     steps:


### PR DESCRIPTION
Release builds keep failing and I saw that they aren't using our token. This adds our token to the commands to publish the docs