### PR TITLE
update operator manifest with bctl verify changes

### DIFF
--- a/deploy/static/boundless-operator.yaml
+++ b/deploy/static/boundless-operator.yaml
@@ -80,6 +80,8 @@ spec:
                 - repo
                 - version
                 type: object
+              dryRun:
+                type: boolean
               enabled:
                 type: boolean
               kind:
@@ -175,6 +177,7 @@ spec:
               namespace:
                 type: string
             required:
+            - dryRun
             - enabled
             - kind
             - name
@@ -276,6 +279,8 @@ spec:
                           - repo
                           - version
                           type: object
+                        dryRun:
+                          type: boolean
                         enabled:
                           type: boolean
                         kind:
@@ -371,6 +376,7 @@ spec:
                         namespace:
                           type: string
                       required:
+                      - dryRun
                       - enabled
                       - kind
                       - name


### PR DESCRIPTION
Missed to update the operator manifest in boundless repo with the dry run PRs. 