### PR TITLE
Add cert-manager resources to the blueprint

### DIFF
--- a/deploy/static/boundless-operator.yaml
+++ b/deploy/static/boundless-operator.yaml
@@ -16,7 +16,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-    controller-gen.kubebuilder.io/version: v0.11.1
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: addons.boundless.mirantis.com
 spec:
   conversion:
@@ -28,7 +28,7 @@ spec:
           namespace: boundless-system
           path: /convert
       conversionReviewVersions:
-      - v1
+        - v1
   group: boundless.mirantis.com
   names:
     kind: Addon
@@ -37,183 +37,214 @@ spec:
     singular: addon
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Whether the component is running and stable.
-      jsonPath: .status.type
-      name: Status
-      type: string
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: Addon is the Schema for the addons API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: AddonSpec defines the desired state of Addon
-            properties:
-              chart:
-                properties:
-                  name:
-                    type: string
-                  repo:
-                    type: string
-                  set:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      x-kubernetes-int-or-string: true
-                    type: object
-                  values:
-                    type: string
-                  version:
-                    type: string
-                required:
+    - additionalPrinterColumns:
+        - description: Whether the component is running and stable.
+          jsonPath: .status.type
+          name: Status
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Addon is the Schema for the addons API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: AddonSpec defines the desired state of Addon
+              properties:
+                chart:
+                  properties:
+                    name:
+                      type: string
+                    repo:
+                      type: string
+                    set:
+                      additionalProperties:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        x-kubernetes-int-or-string: true
+                      type: object
+                    values:
+                      type: string
+                    version:
+                      type: string
+                  required:
+                    - name
+                    - repo
+                    - version
+                  type: object
+                dryRun:
+                  type: boolean
+                enabled:
+                  type: boolean
+                kind:
+                  enum:
+                    - manifest
+                    - chart
+                    - Manifest
+                    - Chart
+                  type: string
+                manifest:
+                  properties:
+                    failurePolicy:
+                      description: "This flag tells the controller how to handle the manifest in case of a failure.\nValid values are:\n- None (default) : No-op; No action is triggered on manifest failure\n- Retry : Manifest is retried in case of failure. For install, the manifest resources are deleted and re-installed.\n\t\t\t For update, the new version of the manifest is applied on top of existing resources."
+                      type: string
+                    timeout:
+                      description: |-
+                        Timeout for manifest operations as duration string (300s, 10m, 1h, etc)
+                        If manifest is not Available after timeout duration, it will be handled by specified FailurePolicy
+                      type: string
+                    url:
+                      minLength: 1
+                      type: string
+                    values:
+                      properties:
+                        images:
+                          description: |-
+                            Images is a list of (image name, new name, new tag or digest)
+                            for changing image names, tags or digests. This can also be achieved with a
+                            patch, but this operator is simpler to specify.
+                          items:
+                            description: Image contains an image name, a new name, a new tag or digest, which will replace the original name and tag.
+                            properties:
+                              digest:
+                                description: |-
+                                  Digest is the value used to replace the original image tag.
+                                  If digest is present NewTag value is ignored.
+                                type: string
+                              name:
+                                description: Name is a tag-less image name.
+                                type: string
+                              newName:
+                                description: NewName is the value used to replace the original name.
+                                type: string
+                              newTag:
+                                description: NewTag is the value used to replace the original tag.
+                                type: string
+                              tagSuffix:
+                                description: |-
+                                  TagSuffix is the value used to suffix the original tag
+                                  If Digest and NewTag is present an error is thrown
+                                type: string
+                            type: object
+                          type: array
+                        patches:
+                          description: |-
+                            Patches is a list of patches, where each one can be either a
+                            Strategic Merge Patch or a JSON patch.
+                            Each patch can be applied to multiple target objects.
+                          items:
+                            description: |-
+                              Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
+                              be applied to. This is in coherence with https://github.com/kubernetes-sigs/kustomize/blob/api/v0.16.0/api/types/patch.go#L12
+                            properties:
+                              options:
+                                additionalProperties:
+                                  type: boolean
+                                description: Options is a list of options for the patch
+                                type: object
+                              patch:
+                                description: |-
+                                  Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
+                                  an array of operation objects.
+                                type: string
+                              path:
+                                description: Path is a relative file path to the patch file.
+                                type: string
+                              target:
+                                description: Target points to the resources that the patch document should be applied to.
+                                properties:
+                                  annotationSelector:
+                                    description: |-
+                                      AnnotationSelector is a string that follows the label selection expression
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                      It matches with the resource annotations.
+                                    type: string
+                                  group:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  labelSelector:
+                                    description: |-
+                                      LabelSelector is a string that follows the label selection expression
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                      It matches with the resource labels.
+                                    type: string
+                                  name:
+                                    description: Name of the resource.
+                                    type: string
+                                  namespace:
+                                    description: Namespace the resource belongs to, if it can belong to a namespace.
+                                    type: string
+                                  version:
+                                    type: string
+                                type: object
+                            required:
+                              - patch
+                            type: object
+                          type: array
+                      type: object
+                  required:
+                    - url
+                  type: object
+                name:
+                  type: string
+                namespace:
+                  type: string
+              required:
+                - dryRun
+                - enabled
+                - kind
                 - name
-                - repo
-                - version
-                type: object
-              dryRun:
-                type: boolean
-              enabled:
-                type: boolean
-              kind:
-                enum:
-                - manifest
-                - chart
-                - Manifest
-                - Chart
-                type: string
-              manifest:
-                properties:
-                  failurePolicy:
-                    description: 'This flag tells the controller how to handle the manifest in case of a failure. Valid values are: - None (default) : No-op; No action is triggered on manifest failure - Retry : Manifest is retried in case of failure. For install, the manifest resources are deleted and re-installed. For update, the new version of the manifest is applied on top of existing resources.'
-                    type: string
-                  timeout:
-                    description: Timeout for manifest operations as duration string (300s, 10m, 1h, etc) If manifest is not Available after timeout duration, it will be handled by specified FailurePolicy
-                    type: string
-                  url:
-                    minLength: 1
-                    type: string
-                  values:
-                    properties:
-                      images:
-                        description: Images is a list of (image name, new name, new tag or digest) for changing image names, tags or digests. This can also be achieved with a patch, but this operator is simpler to specify.
-                        items:
-                          description: Image contains an image name, a new name, a new tag or digest, which will replace the original name and tag.
-                          properties:
-                            digest:
-                              description: Digest is the value used to replace the original image tag. If digest is present NewTag value is ignored.
-                              type: string
-                            name:
-                              description: Name is a tag-less image name.
-                              type: string
-                            newName:
-                              description: NewName is the value used to replace the original name.
-                              type: string
-                            newTag:
-                              description: NewTag is the value used to replace the original tag.
-                              type: string
-                            tagSuffix:
-                              description: TagSuffix is the value used to suffix the original tag If Digest and NewTag is present an error is thrown
-                              type: string
-                          type: object
-                        type: array
-                      patches:
-                        description: Patches is a list of patches, where each one can be either a Strategic Merge Patch or a JSON patch. Each patch can be applied to multiple target objects.
-                        items:
-                          description: Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should be applied to. This is in coherence with https://github.com/kubernetes-sigs/kustomize/blob/api/v0.16.0/api/types/patch.go#L12
-                          properties:
-                            options:
-                              additionalProperties:
-                                type: boolean
-                              description: Options is a list of options for the patch
-                              type: object
-                            patch:
-                              description: Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with an array of operation objects.
-                              type: string
-                            path:
-                              description: Path is a relative file path to the patch file.
-                              type: string
-                            target:
-                              description: Target points to the resources that the patch document should be applied to.
-                              properties:
-                                annotationSelector:
-                                  description: AnnotationSelector is a string that follows the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api It matches with the resource annotations.
-                                  type: string
-                                group:
-                                  type: string
-                                kind:
-                                  type: string
-                                labelSelector:
-                                  description: LabelSelector is a string that follows the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api It matches with the resource labels.
-                                  type: string
-                                name:
-                                  description: Name of the resource.
-                                  type: string
-                                namespace:
-                                  description: Namespace the resource belongs to, if it can belong to a namespace.
-                                  type: string
-                                version:
-                                  type: string
-                              type: object
-                          required:
-                          - patch
-                          type: object
-                        type: array
-                    type: object
-                required:
-                - url
-                type: object
-              name:
-                type: string
-              namespace:
-                type: string
-            required:
-            - dryRun
-            - enabled
-            - kind
-            - name
-            type: object
-          status:
-            description: AddonStatus defines the observed state of Addon
-            properties:
-              lastTransitionTime:
-                description: The timestamp representing the start time for the current status.
-                format: date-time
-                type: string
-              message:
-                description: Optionally, a detailed message providing additional context.
-                type: string
-              reason:
-                description: A brief reason explaining the condition.
-                type: string
-              type:
-                description: The type of condition. May be Available, Progressing, or Degraded.
-                type: string
-            required:
-            - lastTransitionTime
-            - type
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+              type: object
+            status:
+              description: AddonStatus defines the observed state of Addon
+              properties:
+                lastTransitionTime:
+                  description: The timestamp representing the start time for the current status.
+                  format: date-time
+                  type: string
+                message:
+                  description: Optionally, a detailed message providing additional context.
+                  type: string
+                reason:
+                  description: A brief reason explaining the condition.
+                  type: string
+                type:
+                  description: The type of condition. May be Available, Progressing, or Degraded.
+                  type: string
+              required:
+                - lastTransitionTime
+                - type
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-    controller-gen.kubebuilder.io/version: v0.11.1
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: blueprints.boundless.mirantis.com
 spec:
   conversion:
@@ -225,7 +256,7 @@ spec:
           namespace: boundless-system
           path: /convert
       conversionReviewVersions:
-      - v1
+        - v1
   group: boundless.mirantis.com
   names:
     kind: Blueprint
@@ -234,238 +265,5144 @@ spec:
     singular: blueprint
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: Blueprint is the Schema for the blueprints API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: BlueprintSpec defines the desired state of Blueprint
-            properties:
-              components:
-                description: Components contains all the components that should be installed
-                properties:
-                  addons:
-                    items:
-                      description: AddonSpec defines the desired state of Addon
-                      properties:
-                        chart:
-                          properties:
-                            name:
-                              type: string
-                            repo:
-                              type: string
-                            set:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                              type: object
-                            values:
-                              type: string
-                            version:
-                              type: string
-                          required:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Blueprint is the Schema for the blueprints API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: BlueprintSpec defines the desired state of Blueprint
+              properties:
+                components:
+                  description: Components contains all the components that should be installed
+                  properties:
+                    addons:
+                      items:
+                        description: AddonSpec defines the desired state of Addon
+                        properties:
+                          chart:
+                            properties:
+                              name:
+                                type: string
+                              repo:
+                                type: string
+                              set:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              values:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - name
+                              - repo
+                              - version
+                            type: object
+                          dryRun:
+                            type: boolean
+                          enabled:
+                            type: boolean
+                          kind:
+                            enum:
+                              - manifest
+                              - chart
+                              - Manifest
+                              - Chart
+                            type: string
+                          manifest:
+                            properties:
+                              failurePolicy:
+                                description: "This flag tells the controller how to handle the manifest in case of a failure.\nValid values are:\n- None (default) : No-op; No action is triggered on manifest failure\n- Retry : Manifest is retried in case of failure. For install, the manifest resources are deleted and re-installed.\n\t\t\t For update, the new version of the manifest is applied on top of existing resources."
+                                type: string
+                              timeout:
+                                description: |-
+                                  Timeout for manifest operations as duration string (300s, 10m, 1h, etc)
+                                  If manifest is not Available after timeout duration, it will be handled by specified FailurePolicy
+                                type: string
+                              url:
+                                minLength: 1
+                                type: string
+                              values:
+                                properties:
+                                  images:
+                                    description: |-
+                                      Images is a list of (image name, new name, new tag or digest)
+                                      for changing image names, tags or digests. This can also be achieved with a
+                                      patch, but this operator is simpler to specify.
+                                    items:
+                                      description: Image contains an image name, a new name, a new tag or digest, which will replace the original name and tag.
+                                      properties:
+                                        digest:
+                                          description: |-
+                                            Digest is the value used to replace the original image tag.
+                                            If digest is present NewTag value is ignored.
+                                          type: string
+                                        name:
+                                          description: Name is a tag-less image name.
+                                          type: string
+                                        newName:
+                                          description: NewName is the value used to replace the original name.
+                                          type: string
+                                        newTag:
+                                          description: NewTag is the value used to replace the original tag.
+                                          type: string
+                                        tagSuffix:
+                                          description: |-
+                                            TagSuffix is the value used to suffix the original tag
+                                            If Digest and NewTag is present an error is thrown
+                                          type: string
+                                      type: object
+                                    type: array
+                                  patches:
+                                    description: |-
+                                      Patches is a list of patches, where each one can be either a
+                                      Strategic Merge Patch or a JSON patch.
+                                      Each patch can be applied to multiple target objects.
+                                    items:
+                                      description: |-
+                                        Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
+                                        be applied to. This is in coherence with https://github.com/kubernetes-sigs/kustomize/blob/api/v0.16.0/api/types/patch.go#L12
+                                      properties:
+                                        options:
+                                          additionalProperties:
+                                            type: boolean
+                                          description: Options is a list of options for the patch
+                                          type: object
+                                        patch:
+                                          description: |-
+                                            Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
+                                            an array of operation objects.
+                                          type: string
+                                        path:
+                                          description: Path is a relative file path to the patch file.
+                                          type: string
+                                        target:
+                                          description: Target points to the resources that the patch document should be applied to.
+                                          properties:
+                                            annotationSelector:
+                                              description: |-
+                                                AnnotationSelector is a string that follows the label selection expression
+                                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                                It matches with the resource annotations.
+                                              type: string
+                                            group:
+                                              type: string
+                                            kind:
+                                              type: string
+                                            labelSelector:
+                                              description: |-
+                                                LabelSelector is a string that follows the label selection expression
+                                                https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                                It matches with the resource labels.
+                                              type: string
+                                            name:
+                                              description: Name of the resource.
+                                              type: string
+                                            namespace:
+                                              description: Namespace the resource belongs to, if it can belong to a namespace.
+                                              type: string
+                                            version:
+                                              type: string
+                                          type: object
+                                      required:
+                                        - patch
+                                      type: object
+                                    type: array
+                                type: object
+                            required:
+                              - url
+                            type: object
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        required:
+                          - dryRun
+                          - enabled
+                          - kind
                           - name
-                          - repo
-                          - version
-                          type: object
-                        dryRun:
-                          type: boolean
-                        enabled:
-                          type: boolean
-                        kind:
-                          enum:
-                          - manifest
-                          - chart
-                          - Manifest
-                          - Chart
-                          type: string
-                        manifest:
-                          properties:
-                            failurePolicy:
-                              description: 'This flag tells the controller how to handle the manifest in case of a failure. Valid values are: - None (default) : No-op; No action is triggered on manifest failure - Retry : Manifest is retried in case of failure. For install, the manifest resources are deleted and re-installed. For update, the new version of the manifest is applied on top of existing resources.'
-                              type: string
-                            timeout:
-                              description: Timeout for manifest operations as duration string (300s, 10m, 1h, etc) If manifest is not Available after timeout duration, it will be handled by specified FailurePolicy
-                              type: string
-                            url:
-                              minLength: 1
-                              type: string
-                            values:
-                              properties:
-                                images:
-                                  description: Images is a list of (image name, new name, new tag or digest) for changing image names, tags or digests. This can also be achieved with a patch, but this operator is simpler to specify.
-                                  items:
-                                    description: Image contains an image name, a new name, a new tag or digest, which will replace the original name and tag.
+                        type: object
+                      type: array
+                  type: object
+                resources:
+                  description: Resources contains all object resources that should be installed
+                  properties:
+                    certManagement:
+                      description: CertManagement defines the desired state of cert-manager resources
+                      properties:
+                        certificates:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                              spec:
+                                description: |-
+                                  CertificateSpec defines the desired state of Certificate.
+                                  
+                                  
+                                  NOTE: The specification contains a lot of "requested" certificate attributes, it is
+                                  important to note that the issuer can choose to ignore or change any of
+                                  these requested attributes. How the issuer maps a certificate request to a
+                                  signed certificate is the full responsibility of the issuer itself. For example,
+                                  as an edge case, an issuer that inverts the isCA value is free to do so.
+                                  
+                                  
+                                  A valid Certificate requires at least one of a CommonName, LiteralSubject, DNSName, or
+                                  URI to be valid.
+                                properties:
+                                  additionalOutputFormats:
+                                    description: |-
+                                      Defines extra output formats of the private key and signed certificate chain
+                                      to be written to this Certificate's target Secret.
+                                      
+                                      
+                                      This is an Alpha Feature and is only enabled with the
+                                      `--feature-gates=AdditionalCertificateOutputFormats=true` option set on both
+                                      the controller and webhook components.
+                                    items:
+                                      description: |-
+                                        CertificateAdditionalOutputFormat defines an additional output format of a
+                                        Certificate resource. These contain supplementary data formats of the signed
+                                        certificate chain and paired private key.
+                                      properties:
+                                        type:
+                                          description: |-
+                                            Type is the name of the format type that should be written to the
+                                            Certificate's target Secret.
+                                          enum:
+                                            - DER
+                                            - CombinedPEM
+                                          type: string
+                                      required:
+                                        - type
+                                      type: object
+                                    type: array
+                                  commonName:
+                                    description: |-
+                                      Requested common name X509 certificate subject attribute.
+                                      More info: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6
+                                      NOTE: TLS clients will ignore this value when any subject alternative name is
+                                      set (see https://tools.ietf.org/html/rfc6125#section-6.4.4).
+                                      
+                                      
+                                      Should have a length of 64 characters or fewer to avoid generating invalid CSRs.
+                                      Cannot be set if the `literalSubject` field is set.
+                                    type: string
+                                  dnsNames:
+                                    description: Requested DNS subject alternative names.
+                                    items:
+                                      type: string
+                                    type: array
+                                  duration:
+                                    description: |-
+                                      Requested 'duration' (i.e. lifetime) of the Certificate. Note that the
+                                      issuer may choose to ignore the requested duration, just like any other
+                                      requested attribute.
+                                      
+                                      
+                                      If unset, this defaults to 90 days.
+                                      Minimum accepted duration is 1 hour.
+                                      Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+                                    type: string
+                                  emailAddresses:
+                                    description: Requested email subject alternative names.
+                                    items:
+                                      type: string
+                                    type: array
+                                  encodeUsagesInRequest:
+                                    description: |-
+                                      Whether the KeyUsage and ExtKeyUsage extensions should be set in the encoded CSR.
+                                      
+                                      
+                                      This option defaults to true, and should only be disabled if the target
+                                      issuer does not support CSRs with these X509 KeyUsage/ ExtKeyUsage extensions.
+                                    type: boolean
+                                  ipAddresses:
+                                    description: Requested IP address subject alternative names.
+                                    items:
+                                      type: string
+                                    type: array
+                                  isCA:
+                                    description: |-
+                                      Requested basic constraints isCA value.
+                                      The isCA value is used to set the `isCA` field on the created CertificateRequest
+                                      resources. Note that the issuer may choose to ignore the requested isCA value, just
+                                      like any other requested attribute.
+                                      
+                                      
+                                      If true, this will automatically add the `cert sign` usage to the list
+                                      of requested `usages`.
+                                    type: boolean
+                                  issuerRef:
+                                    description: |-
+                                      Reference to the issuer responsible for issuing the certificate.
+                                      If the issuer is namespace-scoped, it must be in the same namespace
+                                      as the Certificate. If the issuer is cluster-scoped, it can be used
+                                      from any namespace.
+                                      
+                                      
+                                      The `name` field of the reference must always be specified.
                                     properties:
-                                      digest:
-                                        description: Digest is the value used to replace the original image tag. If digest is present NewTag value is ignored.
+                                      group:
+                                        description: Group of the resource being referred to.
+                                        type: string
+                                      kind:
+                                        description: Kind of the resource being referred to.
                                         type: string
                                       name:
-                                        description: Name is a tag-less image name.
+                                        description: Name of the resource being referred to.
                                         type: string
-                                      newName:
-                                        description: NewName is the value used to replace the original name.
-                                        type: string
-                                      newTag:
-                                        description: NewTag is the value used to replace the original tag.
-                                        type: string
-                                      tagSuffix:
-                                        description: TagSuffix is the value used to suffix the original tag If Digest and NewTag is present an error is thrown
-                                        type: string
+                                    required:
+                                      - name
                                     type: object
-                                  type: array
-                                patches:
-                                  description: Patches is a list of patches, where each one can be either a Strategic Merge Patch or a JSON patch. Each patch can be applied to multiple target objects.
-                                  items:
-                                    description: Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should be applied to. This is in coherence with https://github.com/kubernetes-sigs/kustomize/blob/api/v0.16.0/api/types/patch.go#L12
+                                  keystores:
+                                    description: Additional keystore output formats to be stored in the Certificate's Secret.
                                     properties:
-                                      options:
-                                        additionalProperties:
-                                          type: boolean
-                                        description: Options is a list of options for the patch
-                                        type: object
-                                      patch:
-                                        description: Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with an array of operation objects.
-                                        type: string
-                                      path:
-                                        description: Path is a relative file path to the patch file.
-                                        type: string
-                                      target:
-                                        description: Target points to the resources that the patch document should be applied to.
+                                      jks:
+                                        description: |-
+                                          JKS configures options for storing a JKS keystore in the
+                                          `spec.secretName` Secret resource.
                                         properties:
-                                          annotationSelector:
-                                            description: AnnotationSelector is a string that follows the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api It matches with the resource annotations.
+                                          create:
+                                            description: |-
+                                              Create enables JKS keystore creation for the Certificate.
+                                              If true, a file named `keystore.jks` will be created in the target
+                                              Secret resource, encrypted using the password stored in
+                                              `passwordSecretRef`.
+                                              The keystore file will be updated immediately.
+                                              If the issuer provided a CA certificate, a file named `truststore.jks`
+                                              will also be created in the target Secret resource, encrypted using the
+                                              password stored in `passwordSecretRef`
+                                              containing the issuing Certificate Authority
+                                            type: boolean
+                                          passwordSecretRef:
+                                            description: |-
+                                              PasswordSecretRef is a reference to a key in a Secret resource
+                                              containing the password used to encrypt the JKS keystore.
+                                            properties:
+                                              key:
+                                                description: |-
+                                                  The key of the entry in the Secret resource's `data` field to be used.
+                                                  Some instances of this field may be defaulted, in others it may be
+                                                  required.
+                                                type: string
+                                              name:
+                                                description: |-
+                                                  Name of the resource being referred to.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                            required:
+                                              - name
+                                            type: object
+                                        required:
+                                          - create
+                                          - passwordSecretRef
+                                        type: object
+                                      pkcs12:
+                                        description: |-
+                                          PKCS12 configures options for storing a PKCS12 keystore in the
+                                          `spec.secretName` Secret resource.
+                                        properties:
+                                          create:
+                                            description: |-
+                                              Create enables PKCS12 keystore creation for the Certificate.
+                                              If true, a file named `keystore.p12` will be created in the target
+                                              Secret resource, encrypted using the password stored in
+                                              `passwordSecretRef`.
+                                              The keystore file will be updated immediately.
+                                              If the issuer provided a CA certificate, a file named `truststore.p12` will
+                                              also be created in the target Secret resource, encrypted using the
+                                              password stored in `passwordSecretRef` containing the issuing Certificate
+                                              Authority
+                                            type: boolean
+                                          passwordSecretRef:
+                                            description: |-
+                                              PasswordSecretRef is a reference to a key in a Secret resource
+                                              containing the password used to encrypt the PKCS12 keystore.
+                                            properties:
+                                              key:
+                                                description: |-
+                                                  The key of the entry in the Secret resource's `data` field to be used.
+                                                  Some instances of this field may be defaulted, in others it may be
+                                                  required.
+                                                type: string
+                                              name:
+                                                description: |-
+                                                  Name of the resource being referred to.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                            required:
+                                              - name
+                                            type: object
+                                          profile:
+                                            description: |-
+                                              Profile specifies the key and certificate encryption algorithms and the HMAC algorithm
+                                              used to create the PKCS12 keystore. Default value is `LegacyRC2` for backward compatibility.
+                                              
+                                              
+                                              If provided, allowed values are:
+                                              `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
+                                              `LegacyDES`: Less secure algorithm. Use this option for maximal compatibility.
+                                              `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms
+                                              (eg. because of company policy). Please note that the security of the algorithm is not that important
+                                              in reality, because the unencrypted certificate and private key are also stored in the Secret.
+                                            enum:
+                                              - LegacyRC2
+                                              - LegacyDES
+                                              - Modern2023
                                             type: string
-                                          group:
+                                        required:
+                                          - create
+                                          - passwordSecretRef
+                                        type: object
+                                    type: object
+                                  literalSubject:
+                                    description: |-
+                                      Requested X.509 certificate subject, represented using the LDAP "String
+                                      Representation of a Distinguished Name" [1].
+                                      Important: the LDAP string format also specifies the order of the attributes
+                                      in the subject, this is important when issuing certs for LDAP authentication.
+                                      Example: `CN=foo,DC=corp,DC=example,DC=com`
+                                      More info [1]: https://datatracker.ietf.org/doc/html/rfc4514
+                                      More info: https://github.com/cert-manager/cert-manager/issues/3203
+                                      More info: https://github.com/cert-manager/cert-manager/issues/4424
+                                      
+                                      
+                                      Cannot be set if the `subject` or `commonName` field is set.
+                                      This is an Alpha Feature and is only enabled with the
+                                      `--feature-gates=LiteralCertificateSubject=true` option set on both
+                                      the controller and webhook components.
+                                    type: string
+                                  nameConstraints:
+                                    description: |-
+                                      x.509 certificate NameConstraint extension which MUST NOT be used in a non-CA certificate.
+                                      More Info: https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.10
+                                      
+                                      
+                                      This is an Alpha Feature and is only enabled with the
+                                      `--feature-gates=NameConstraints=true` option set on both
+                                      the controller and webhook components.
+                                    properties:
+                                      critical:
+                                        description: if true then the name constraints are marked critical.
+                                        type: boolean
+                                      excluded:
+                                        description: |-
+                                          Excluded contains the constraints which must be disallowed. Any name matching a
+                                          restriction in the excluded field is invalid regardless
+                                          of information appearing in the permitted
+                                        properties:
+                                          dnsDomains:
+                                            description: DNSDomains is a list of DNS domains that are permitted or excluded.
+                                            items:
+                                              type: string
+                                            type: array
+                                          emailAddresses:
+                                            description: EmailAddresses is a list of Email Addresses that are permitted or excluded.
+                                            items:
+                                              type: string
+                                            type: array
+                                          ipRanges:
+                                            description: |-
+                                              IPRanges is a list of IP Ranges that are permitted or excluded.
+                                              This should be a valid CIDR notation.
+                                            items:
+                                              type: string
+                                            type: array
+                                          uriDomains:
+                                            description: URIDomains is a list of URI domains that are permitted or excluded.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      permitted:
+                                        description: Permitted contains the constraints in which the names must be located.
+                                        properties:
+                                          dnsDomains:
+                                            description: DNSDomains is a list of DNS domains that are permitted or excluded.
+                                            items:
+                                              type: string
+                                            type: array
+                                          emailAddresses:
+                                            description: EmailAddresses is a list of Email Addresses that are permitted or excluded.
+                                            items:
+                                              type: string
+                                            type: array
+                                          ipRanges:
+                                            description: |-
+                                              IPRanges is a list of IP Ranges that are permitted or excluded.
+                                              This should be a valid CIDR notation.
+                                            items:
+                                              type: string
+                                            type: array
+                                          uriDomains:
+                                            description: URIDomains is a list of URI domains that are permitted or excluded.
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                    type: object
+                                  otherNames:
+                                    description: |-
+                                      `otherNames` is an escape hatch for SAN that allows any type. We currently restrict the support to string like otherNames, cf RFC 5280 p 37
+                                      Any UTF8 String valued otherName can be passed with by setting the keys oid: x.x.x.x and UTF8Value: somevalue for `otherName`.
+                                      Most commonly this would be UPN set with oid: 1.3.6.1.4.1.311.20.2.3
+                                      You should ensure that any OID passed is valid for the UTF8String type as we do not explicitly validate this.
+                                    items:
+                                      properties:
+                                        oid:
+                                          description: |-
+                                            OID is the object identifier for the otherName SAN.
+                                            The object identifier must be expressed as a dotted string, for
+                                            example, "1.2.840.113556.1.4.221".
+                                          type: string
+                                        utf8Value:
+                                          description: |-
+                                            utf8Value is the string value of the otherName SAN.
+                                            The utf8Value accepts any valid UTF8 string to set as value for the otherName SAN.
+                                          type: string
+                                      type: object
+                                    type: array
+                                  privateKey:
+                                    description: |-
+                                      Private key options. These include the key algorithm and size, the used
+                                      encoding and the rotation policy.
+                                    properties:
+                                      algorithm:
+                                        description: |-
+                                          Algorithm is the private key algorithm of the corresponding private key
+                                          for this certificate.
+                                          
+                                          
+                                          If provided, allowed values are either `RSA`, `ECDSA` or `Ed25519`.
+                                          If `algorithm` is specified and `size` is not provided,
+                                          key size of 2048 will be used for `RSA` key algorithm and
+                                          key size of 256 will be used for `ECDSA` key algorithm.
+                                          key size is ignored when using the `Ed25519` key algorithm.
+                                        enum:
+                                          - RSA
+                                          - ECDSA
+                                          - Ed25519
+                                        type: string
+                                      encoding:
+                                        description: |-
+                                          The private key cryptography standards (PKCS) encoding for this
+                                          certificate's private key to be encoded in.
+                                          
+                                          
+                                          If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
+                                          and PKCS#8, respectively.
+                                          Defaults to `PKCS1` if not specified.
+                                        enum:
+                                          - PKCS1
+                                          - PKCS8
+                                        type: string
+                                      rotationPolicy:
+                                        description: |-
+                                          RotationPolicy controls how private keys should be regenerated when a
+                                          re-issuance is being processed.
+                                          
+                                          
+                                          If set to `Never`, a private key will only be generated if one does not
+                                          already exist in the target `spec.secretName`. If one does exists but it
+                                          does not have the correct algorithm or size, a warning will be raised
+                                          to await user intervention.
+                                          If set to `Always`, a private key matching the specified requirements
+                                          will be generated whenever a re-issuance occurs.
+                                          Default is `Never` for backward compatibility.
+                                        enum:
+                                          - Never
+                                          - Always
+                                        type: string
+                                      size:
+                                        description: |-
+                                          Size is the key bit size of the corresponding private key for this certificate.
+                                          
+                                          
+                                          If `algorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+                                          and will default to `2048` if not specified.
+                                          If `algorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+                                          and will default to `256` if not specified.
+                                          If `algorithm` is set to `Ed25519`, Size is ignored.
+                                          No other values are allowed.
+                                        type: integer
+                                    type: object
+                                  renewBefore:
+                                    description: |-
+                                      How long before the currently issued certificate's expiry cert-manager should
+                                      renew the certificate. For example, if a certificate is valid for 60 minutes,
+                                      and `renewBefore=10m`, cert-manager will begin to attempt to renew the certificate
+                                      50 minutes after it was issued (i.e. when there are 10 minutes remaining until
+                                      the certificate is no longer valid).
+                                      
+                                      
+                                      NOTE: The actual lifetime of the issued certificate is used to determine the
+                                      renewal time. If an issuer returns a certificate with a different lifetime than
+                                      the one requested, cert-manager will use the lifetime of the issued certificate.
+                                      
+                                      
+                                      If unset, this defaults to 1/3 of the issued certificate's lifetime.
+                                      Minimum accepted value is 5 minutes.
+                                      Value must be in units accepted by Go time.ParseDuration https://golang.org/pkg/time/#ParseDuration.
+                                    type: string
+                                  revisionHistoryLimit:
+                                    description: |-
+                                      The maximum number of CertificateRequest revisions that are maintained in
+                                      the Certificate's history. Each revision represents a single `CertificateRequest`
+                                      created by this Certificate, either when it was created, renewed, or Spec
+                                      was changed. Revisions will be removed by oldest first if the number of
+                                      revisions exceeds this number.
+                                      
+                                      
+                                      If set, revisionHistoryLimit must be a value of `1` or greater.
+                                      If unset (`nil`), revisions will not be garbage collected.
+                                      Default value is `nil`.
+                                    format: int32
+                                    type: integer
+                                  secretName:
+                                    description: |-
+                                      Name of the Secret resource that will be automatically created and
+                                      managed by this Certificate resource. It will be populated with a
+                                      private key and certificate, signed by the denoted issuer. The Secret
+                                      resource lives in the same namespace as the Certificate resource.
+                                    type: string
+                                  secretTemplate:
+                                    description: |-
+                                      Defines annotations and labels to be copied to the Certificate's Secret.
+                                      Labels and annotations on the Secret will be changed as they appear on the
+                                      SecretTemplate when added or removed. SecretTemplate annotations are added
+                                      in conjunction with, and cannot overwrite, the base set of annotations
+                                      cert-manager sets on the Certificate's Secret.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations is a key value map to be copied to the target Kubernetes Secret.
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        description: Labels is a key value map to be copied to the target Kubernetes Secret.
+                                        type: object
+                                    type: object
+                                  subject:
+                                    description: |-
+                                      Requested set of X509 certificate subject attributes.
+                                      More info: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.6
+                                      
+                                      
+                                      The common name attribute is specified separately in the `commonName` field.
+                                      Cannot be set if the `literalSubject` field is set.
+                                    properties:
+                                      countries:
+                                        description: Countries to be used on the Certificate.
+                                        items:
+                                          type: string
+                                        type: array
+                                      localities:
+                                        description: Cities to be used on the Certificate.
+                                        items:
+                                          type: string
+                                        type: array
+                                      organizationalUnits:
+                                        description: Organizational Units to be used on the Certificate.
+                                        items:
+                                          type: string
+                                        type: array
+                                      organizations:
+                                        description: Organizations to be used on the Certificate.
+                                        items:
+                                          type: string
+                                        type: array
+                                      postalCodes:
+                                        description: Postal codes to be used on the Certificate.
+                                        items:
+                                          type: string
+                                        type: array
+                                      provinces:
+                                        description: State/Provinces to be used on the Certificate.
+                                        items:
+                                          type: string
+                                        type: array
+                                      serialNumber:
+                                        description: Serial number to be used on the Certificate.
+                                        type: string
+                                      streetAddresses:
+                                        description: Street addresses to be used on the Certificate.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  uris:
+                                    description: Requested URI subject alternative names.
+                                    items:
+                                      type: string
+                                    type: array
+                                  usages:
+                                    description: |-
+                                      Requested key usages and extended key usages.
+                                      These usages are used to set the `usages` field on the created CertificateRequest
+                                      resources. If `encodeUsagesInRequest` is unset or set to `true`, the usages
+                                      will additionally be encoded in the `request` field which contains the CSR blob.
+                                      
+                                      
+                                      If unset, defaults to `digital signature` and `key encipherment`.
+                                    items:
+                                      description: |-
+                                        KeyUsage specifies valid usage contexts for keys.
+                                        See:
+                                        https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+                                        https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+                                        
+                                        
+                                        Valid KeyUsage values are as follows:
+                                        "signing",
+                                        "digital signature",
+                                        "content commitment",
+                                        "key encipherment",
+                                        "key agreement",
+                                        "data encipherment",
+                                        "cert sign",
+                                        "crl sign",
+                                        "encipher only",
+                                        "decipher only",
+                                        "any",
+                                        "server auth",
+                                        "client auth",
+                                        "code signing",
+                                        "email protection",
+                                        "s/mime",
+                                        "ipsec end system",
+                                        "ipsec tunnel",
+                                        "ipsec user",
+                                        "timestamping",
+                                        "ocsp signing",
+                                        "microsoft sgc",
+                                        "netscape sgc"
+                                      enum:
+                                        - signing
+                                        - digital signature
+                                        - content commitment
+                                        - key encipherment
+                                        - key agreement
+                                        - data encipherment
+                                        - cert sign
+                                        - crl sign
+                                        - encipher only
+                                        - decipher only
+                                        - any
+                                        - server auth
+                                        - client auth
+                                        - code signing
+                                        - email protection
+                                        - s/mime
+                                        - ipsec end system
+                                        - ipsec tunnel
+                                        - ipsec user
+                                        - timestamping
+                                        - ocsp signing
+                                        - microsoft sgc
+                                        - netscape sgc
+                                      type: string
+                                    type: array
+                                required:
+                                  - issuerRef
+                                  - secretName
+                                type: object
+                            required:
+                              - name
+                              - namespace
+                              - spec
+                            type: object
+                          type: array
+                        clusterIssuers:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              spec:
+                                description: |-
+                                  IssuerSpec is the specification of an Issuer. This includes any
+                                  configuration required for the issuer.
+                                properties:
+                                  acme:
+                                    description: |-
+                                      ACME configures this issuer to communicate with a RFC8555 (ACME) server
+                                      to obtain signed x509 certificates.
+                                    properties:
+                                      caBundle:
+                                        description: |-
+                                          Base64-encoded bundle of PEM CAs which can be used to validate the certificate
+                                          chain presented by the ACME server.
+                                          Mutually exclusive with SkipTLSVerify; prefer using CABundle to prevent various
+                                          kinds of security vulnerabilities.
+                                          If CABundle and SkipTLSVerify are unset, the system certificate bundle inside
+                                          the container is used to validate the TLS connection.
+                                        format: byte
+                                        type: string
+                                      disableAccountKeyGeneration:
+                                        description: |-
+                                          Enables or disables generating a new ACME account key.
+                                          If true, the Issuer resource will *not* request a new account but will expect
+                                          the account key to be supplied via an existing secret.
+                                          If false, the cert-manager system will generate a new ACME account key
+                                          for the Issuer.
+                                          Defaults to false.
+                                        type: boolean
+                                      email:
+                                        description: |-
+                                          Email is the email address to be associated with the ACME account.
+                                          This field is optional, but it is strongly recommended to be set.
+                                          It will be used to contact you in case of issues with your account or
+                                          certificates, including expiry notification emails.
+                                          This field may be updated after the account is initially registered.
+                                        type: string
+                                      enableDurationFeature:
+                                        description: |-
+                                          Enables requesting a Not After date on certificates that matches the
+                                          duration of the certificate. This is not supported by all ACME servers
+                                          like Let's Encrypt. If set to true when the ACME server does not support
+                                          it it will create an error on the Order.
+                                          Defaults to false.
+                                        type: boolean
+                                      externalAccountBinding:
+                                        description: |-
+                                          ExternalAccountBinding is a reference to a CA external account of the ACME
+                                          server.
+                                          If set, upon registration cert-manager will attempt to associate the given
+                                          external account credentials with the registered ACME account.
+                                        properties:
+                                          keyAlgorithm:
+                                            description: |-
+                                              Deprecated: keyAlgorithm field exists for historical compatibility
+                                              reasons and should not be used. The algorithm is now hardcoded to HS256
+                                              in golang/x/crypto/acme.
+                                            enum:
+                                              - HS256
+                                              - HS384
+                                              - HS512
                                             type: string
-                                          kind:
+                                          keyID:
+                                            description: keyID is the ID of the CA key that the External Account is bound to.
                                             type: string
-                                          labelSelector:
-                                            description: LabelSelector is a string that follows the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api It matches with the resource labels.
+                                          keySecretRef:
+                                            description: |-
+                                              keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes
+                                              Secret which holds the symmetric MAC key of the External Account Binding.
+                                              The `key` is the index string that is paired with the key data in the
+                                              Secret and should not be confused with the key data itself, or indeed with
+                                              the External Account Binding keyID above.
+                                              The secret key stored in the Secret **must** be un-padded, base64 URL
+                                              encoded data.
+                                            properties:
+                                              key:
+                                                description: |-
+                                                  The key of the entry in the Secret resource's `data` field to be used.
+                                                  Some instances of this field may be defaulted, in others it may be
+                                                  required.
+                                                type: string
+                                              name:
+                                                description: |-
+                                                  Name of the resource being referred to.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                            required:
+                                              - name
+                                            type: object
+                                        required:
+                                          - keyID
+                                          - keySecretRef
+                                        type: object
+                                      preferredChain:
+                                        description: |-
+                                          PreferredChain is the chain to use if the ACME server outputs multiple.
+                                          PreferredChain is no guarantee that this one gets delivered by the ACME
+                                          endpoint.
+                                          For example, for Let's Encrypt's DST crosssign you would use:
+                                          "DST Root CA X3" or "ISRG Root X1" for the newer Let's Encrypt root CA.
+                                          This value picks the first certificate bundle in the ACME alternative
+                                          chains that has a certificate with this value as its issuer's CN
+                                        maxLength: 64
+                                        type: string
+                                      privateKeySecretRef:
+                                        description: |-
+                                          PrivateKey is the name of a Kubernetes Secret resource that will be used to
+                                          store the automatically generated ACME account private key.
+                                          Optionally, a `key` may be specified to select a specific entry within
+                                          the named Secret resource.
+                                          If `key` is not specified, a default of `tls.key` will be used.
+                                        properties:
+                                          key:
+                                            description: |-
+                                              The key of the entry in the Secret resource's `data` field to be used.
+                                              Some instances of this field may be defaulted, in others it may be
+                                              required.
                                             type: string
                                           name:
-                                            description: Name of the resource.
+                                            description: |-
+                                              Name of the resource being referred to.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                             type: string
-                                          namespace:
-                                            description: Namespace the resource belongs to, if it can belong to a namespace.
-                                            type: string
-                                          version:
-                                            type: string
+                                        required:
+                                          - name
                                         type: object
+                                      server:
+                                        description: |-
+                                          Server is the URL used to access the ACME server's 'directory' endpoint.
+                                          For example, for Let's Encrypt's staging endpoint, you would use:
+                                          "https://acme-staging-v02.api.letsencrypt.org/directory".
+                                          Only ACME v2 endpoints (i.e. RFC 8555) are supported.
+                                        type: string
+                                      skipTLSVerify:
+                                        description: |-
+                                          INSECURE: Enables or disables validation of the ACME server TLS certificate.
+                                          If true, requests to the ACME server will not have the TLS certificate chain
+                                          validated.
+                                          Mutually exclusive with CABundle; prefer using CABundle to prevent various
+                                          kinds of security vulnerabilities.
+                                          Only enable this option in development environments.
+                                          If CABundle and SkipTLSVerify are unset, the system certificate bundle inside
+                                          the container is used to validate the TLS connection.
+                                          Defaults to false.
+                                        type: boolean
+                                      solvers:
+                                        description: |-
+                                          Solvers is a list of challenge solvers that will be used to solve
+                                          ACME challenges for the matching domains.
+                                          Solver configurations must be provided in order to obtain certificates
+                                          from an ACME server.
+                                          For more information, see: https://cert-manager.io/docs/configuration/acme/
+                                        items:
+                                          description: |-
+                                            An ACMEChallengeSolver describes how to solve ACME challenges for the issuer it is part of.
+                                            A selector may be provided to use different solving strategies for different DNS names.
+                                            Only one of HTTP01 or DNS01 must be provided.
+                                          properties:
+                                            dns01:
+                                              description: |-
+                                                Configures cert-manager to attempt to complete authorizations by
+                                                performing the DNS01 challenge flow.
+                                              properties:
+                                                acmeDNS:
+                                                  description: |-
+                                                    Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage
+                                                    DNS01 challenge records.
+                                                  properties:
+                                                    accountSecretRef:
+                                                      description: |-
+                                                        A reference to a specific 'key' within a Secret resource.
+                                                        In some instances, `key` is a required field.
+                                                      properties:
+                                                        key:
+                                                          description: |-
+                                                            The key of the entry in the Secret resource's `data` field to be used.
+                                                            Some instances of this field may be defaulted, in others it may be
+                                                            required.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the resource being referred to.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                      type: object
+                                                    host:
+                                                      type: string
+                                                  required:
+                                                    - accountSecretRef
+                                                    - host
+                                                  type: object
+                                                akamai:
+                                                  description: Use the Akamai DNS zone management API to manage DNS01 challenge records.
+                                                  properties:
+                                                    accessTokenSecretRef:
+                                                      description: |-
+                                                        A reference to a specific 'key' within a Secret resource.
+                                                        In some instances, `key` is a required field.
+                                                      properties:
+                                                        key:
+                                                          description: |-
+                                                            The key of the entry in the Secret resource's `data` field to be used.
+                                                            Some instances of this field may be defaulted, in others it may be
+                                                            required.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the resource being referred to.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                      type: object
+                                                    clientSecretSecretRef:
+                                                      description: |-
+                                                        A reference to a specific 'key' within a Secret resource.
+                                                        In some instances, `key` is a required field.
+                                                      properties:
+                                                        key:
+                                                          description: |-
+                                                            The key of the entry in the Secret resource's `data` field to be used.
+                                                            Some instances of this field may be defaulted, in others it may be
+                                                            required.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the resource being referred to.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                      type: object
+                                                    clientTokenSecretRef:
+                                                      description: |-
+                                                        A reference to a specific 'key' within a Secret resource.
+                                                        In some instances, `key` is a required field.
+                                                      properties:
+                                                        key:
+                                                          description: |-
+                                                            The key of the entry in the Secret resource's `data` field to be used.
+                                                            Some instances of this field may be defaulted, in others it may be
+                                                            required.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the resource being referred to.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                      type: object
+                                                    serviceConsumerDomain:
+                                                      type: string
+                                                  required:
+                                                    - accessTokenSecretRef
+                                                    - clientSecretSecretRef
+                                                    - clientTokenSecretRef
+                                                    - serviceConsumerDomain
+                                                  type: object
+                                                azureDNS:
+                                                  description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
+                                                  properties:
+                                                    clientID:
+                                                      description: |-
+                                                        Auth: Azure Service Principal:
+                                                        The ClientID of the Azure Service Principal used to authenticate with Azure DNS.
+                                                        If set, ClientSecret and TenantID must also be set.
+                                                      type: string
+                                                    clientSecretSecretRef:
+                                                      description: |-
+                                                        Auth: Azure Service Principal:
+                                                        A reference to a Secret containing the password associated with the Service Principal.
+                                                        If set, ClientID and TenantID must also be set.
+                                                      properties:
+                                                        key:
+                                                          description: |-
+                                                            The key of the entry in the Secret resource's `data` field to be used.
+                                                            Some instances of this field may be defaulted, in others it may be
+                                                            required.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the resource being referred to.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                      type: object
+                                                    environment:
+                                                      description: name of the Azure environment (default AzurePublicCloud)
+                                                      enum:
+                                                        - AzurePublicCloud
+                                                        - AzureChinaCloud
+                                                        - AzureGermanCloud
+                                                        - AzureUSGovernmentCloud
+                                                      type: string
+                                                    hostedZoneName:
+                                                      description: name of the DNS zone that should be used
+                                                      type: string
+                                                    managedIdentity:
+                                                      description: |-
+                                                        Auth: Azure Workload Identity or Azure Managed Service Identity:
+                                                        Settings to enable Azure Workload Identity or Azure Managed Service Identity
+                                                        If set, ClientID, ClientSecret and TenantID must not be set.
+                                                      properties:
+                                                        clientID:
+                                                          description: client ID of the managed identity, can not be used at the same time as resourceID
+                                                          type: string
+                                                        resourceID:
+                                                          description: |-
+                                                            resource ID of the managed identity, can not be used at the same time as clientID
+                                                            Cannot be used for Azure Managed Service Identity
+                                                          type: string
+                                                      type: object
+                                                    resourceGroupName:
+                                                      description: resource group the DNS zone is located in
+                                                      type: string
+                                                    subscriptionID:
+                                                      description: ID of the Azure subscription
+                                                      type: string
+                                                    tenantID:
+                                                      description: |-
+                                                        Auth: Azure Service Principal:
+                                                        The TenantID of the Azure Service Principal used to authenticate with Azure DNS.
+                                                        If set, ClientID and ClientSecret must also be set.
+                                                      type: string
+                                                  required:
+                                                    - resourceGroupName
+                                                    - subscriptionID
+                                                  type: object
+                                                cloudDNS:
+                                                  description: Use the Google Cloud DNS API to manage DNS01 challenge records.
+                                                  properties:
+                                                    hostedZoneName:
+                                                      description: |-
+                                                        HostedZoneName is an optional field that tells cert-manager in which
+                                                        Cloud DNS zone the challenge record has to be created.
+                                                        If left empty cert-manager will automatically choose a zone.
+                                                      type: string
+                                                    project:
+                                                      type: string
+                                                    serviceAccountSecretRef:
+                                                      description: |-
+                                                        A reference to a specific 'key' within a Secret resource.
+                                                        In some instances, `key` is a required field.
+                                                      properties:
+                                                        key:
+                                                          description: |-
+                                                            The key of the entry in the Secret resource's `data` field to be used.
+                                                            Some instances of this field may be defaulted, in others it may be
+                                                            required.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the resource being referred to.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                      type: object
+                                                  required:
+                                                    - project
+                                                  type: object
+                                                cloudflare:
+                                                  description: Use the Cloudflare API to manage DNS01 challenge records.
+                                                  properties:
+                                                    apiKeySecretRef:
+                                                      description: |-
+                                                        API key to use to authenticate with Cloudflare.
+                                                        Note: using an API token to authenticate is now the recommended method
+                                                        as it allows greater control of permissions.
+                                                      properties:
+                                                        key:
+                                                          description: |-
+                                                            The key of the entry in the Secret resource's `data` field to be used.
+                                                            Some instances of this field may be defaulted, in others it may be
+                                                            required.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the resource being referred to.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                      type: object
+                                                    apiTokenSecretRef:
+                                                      description: API token used to authenticate with Cloudflare.
+                                                      properties:
+                                                        key:
+                                                          description: |-
+                                                            The key of the entry in the Secret resource's `data` field to be used.
+                                                            Some instances of this field may be defaulted, in others it may be
+                                                            required.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the resource being referred to.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                      type: object
+                                                    email:
+                                                      description: Email of the account, only required when using API key based authentication.
+                                                      type: string
+                                                  type: object
+                                                cnameStrategy:
+                                                  description: |-
+                                                    CNAMEStrategy configures how the DNS01 provider should handle CNAME
+                                                    records when found in DNS zones.
+                                                  enum:
+                                                    - None
+                                                    - Follow
+                                                  type: string
+                                                digitalocean:
+                                                  description: Use the DigitalOcean DNS API to manage DNS01 challenge records.
+                                                  properties:
+                                                    tokenSecretRef:
+                                                      description: |-
+                                                        A reference to a specific 'key' within a Secret resource.
+                                                        In some instances, `key` is a required field.
+                                                      properties:
+                                                        key:
+                                                          description: |-
+                                                            The key of the entry in the Secret resource's `data` field to be used.
+                                                            Some instances of this field may be defaulted, in others it may be
+                                                            required.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the resource being referred to.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                      type: object
+                                                  required:
+                                                    - tokenSecretRef
+                                                  type: object
+                                                rfc2136:
+                                                  description: |-
+                                                    Use RFC2136 ("Dynamic Updates in the Domain Name System") (https://datatracker.ietf.org/doc/rfc2136/)
+                                                    to manage DNS01 challenge records.
+                                                  properties:
+                                                    nameserver:
+                                                      description: |-
+                                                        The IP address or hostname of an authoritative DNS server supporting
+                                                        RFC2136 in the form host:port. If the host is an IPv6 address it must be
+                                                        enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                                        This field is required.
+                                                      type: string
+                                                    tsigAlgorithm:
+                                                      description: |-
+                                                        The TSIG Algorithm configured in the DNS supporting RFC2136. Used only
+                                                        when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined.
+                                                        Supported values are (case-insensitive): ``HMACMD5`` (default),
+                                                        ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.
+                                                      type: string
+                                                    tsigKeyName:
+                                                      description: |-
+                                                        The TSIG Key name configured in the DNS.
+                                                        If ``tsigSecretSecretRef`` is defined, this field is required.
+                                                      type: string
+                                                    tsigSecretSecretRef:
+                                                      description: |-
+                                                        The name of the secret containing the TSIG value.
+                                                        If ``tsigKeyName`` is defined, this field is required.
+                                                      properties:
+                                                        key:
+                                                          description: |-
+                                                            The key of the entry in the Secret resource's `data` field to be used.
+                                                            Some instances of this field may be defaulted, in others it may be
+                                                            required.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the resource being referred to.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                      type: object
+                                                  required:
+                                                    - nameserver
+                                                  type: object
+                                                route53:
+                                                  description: Use the AWS Route53 API to manage DNS01 challenge records.
+                                                  properties:
+                                                    accessKeyID:
+                                                      description: |-
+                                                        The AccessKeyID is used for authentication.
+                                                        Cannot be set when SecretAccessKeyID is set.
+                                                        If neither the Access Key nor Key ID are set, we fall-back to using env
+                                                        vars, shared credentials file or AWS Instance metadata,
+                                                        see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                                      type: string
+                                                    accessKeyIDSecretRef:
+                                                      description: |-
+                                                        The SecretAccessKey is used for authentication. If set, pull the AWS
+                                                        access key ID from a key within a Kubernetes Secret.
+                                                        Cannot be set when AccessKeyID is set.
+                                                        If neither the Access Key nor Key ID are set, we fall-back to using env
+                                                        vars, shared credentials file or AWS Instance metadata,
+                                                        see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                                      properties:
+                                                        key:
+                                                          description: |-
+                                                            The key of the entry in the Secret resource's `data` field to be used.
+                                                            Some instances of this field may be defaulted, in others it may be
+                                                            required.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the resource being referred to.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                      type: object
+                                                    hostedZoneID:
+                                                      description: If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.
+                                                      type: string
+                                                    region:
+                                                      description: Always set the region when using AccessKeyID and SecretAccessKey
+                                                      type: string
+                                                    role:
+                                                      description: |-
+                                                        Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey
+                                                        or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata
+                                                      type: string
+                                                    secretAccessKeySecretRef:
+                                                      description: |-
+                                                        The SecretAccessKey is used for authentication.
+                                                        If neither the Access Key nor Key ID are set, we fall-back to using env
+                                                        vars, shared credentials file or AWS Instance metadata,
+                                                        see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                                      properties:
+                                                        key:
+                                                          description: |-
+                                                            The key of the entry in the Secret resource's `data` field to be used.
+                                                            Some instances of this field may be defaulted, in others it may be
+                                                            required.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the resource being referred to.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                      type: object
+                                                  required:
+                                                    - region
+                                                  type: object
+                                                webhook:
+                                                  description: |-
+                                                    Configure an external webhook based DNS01 challenge solver to manage
+                                                    DNS01 challenge records.
+                                                  properties:
+                                                    config:
+                                                      description: |-
+                                                        Additional configuration that should be passed to the webhook apiserver
+                                                        when challenges are processed.
+                                                        This can contain arbitrary JSON data.
+                                                        Secret values should not be specified in this stanza.
+                                                        If secret values are needed (e.g. credentials for a DNS service), you
+                                                        should use a SecretKeySelector to reference a Secret resource.
+                                                        For details on the schema of this field, consult the webhook provider
+                                                        implementation's documentation.
+                                                      x-kubernetes-preserve-unknown-fields: true
+                                                    groupName:
+                                                      description: |-
+                                                        The API group name that should be used when POSTing ChallengePayload
+                                                        resources to the webhook apiserver.
+                                                        This should be the same as the GroupName specified in the webhook
+                                                        provider implementation.
+                                                      type: string
+                                                    solverName:
+                                                      description: |-
+                                                        The name of the solver to use, as defined in the webhook provider
+                                                        implementation.
+                                                        This will typically be the name of the provider, e.g. 'cloudflare'.
+                                                      type: string
+                                                  required:
+                                                    - groupName
+                                                    - solverName
+                                                  type: object
+                                              type: object
+                                            http01:
+                                              description: |-
+                                                Configures cert-manager to attempt to complete authorizations by
+                                                performing the HTTP01 challenge flow.
+                                                It is not possible to obtain certificates for wildcard domain names
+                                                (e.g. `*.example.com`) using the HTTP01 challenge mechanism.
+                                              properties:
+                                                gatewayHTTPRoute:
+                                                  description: |-
+                                                    The Gateway API is a sig-network community API that models service networking
+                                                    in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will
+                                                    create HTTPRoutes with the specified labels in the same namespace as the challenge.
+                                                    This solver is experimental, and fields / behaviour may change in the future.
+                                                  properties:
+                                                    labels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: |-
+                                                        Custom labels that will be applied to HTTPRoutes created by cert-manager
+                                                        while solving HTTP-01 challenges.
+                                                      type: object
+                                                    parentRefs:
+                                                      description: |-
+                                                        When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute.
+                                                        cert-manager needs to know which parentRefs should be used when creating
+                                                        the HTTPRoute. Usually, the parentRef references a Gateway. See:
+                                                        https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways
+                                                      items:
+                                                        description: |-
+                                                          ParentReference identifies an API object (usually a Gateway) that can be considered
+                                                          a parent of this resource (usually a route). There are two kinds of parent resources
+                                                          with "Core" support:
+                                                          
+                                                          
+                                                          * Gateway (Gateway conformance profile)
+                                                          * Service (Mesh conformance profile, experimental, ClusterIP Services only)
+                                                          
+                                                          
+                                                          This API may be extended in the future to support additional kinds of parent
+                                                          resources.
+                                                          
+                                                          
+                                                          The API object must be valid in the cluster; the Group and Kind must
+                                                          be registered in the cluster for this reference to be valid.
+                                                        properties:
+                                                          group:
+                                                            default: gateway.networking.k8s.io
+                                                            description: |-
+                                                              Group is the group of the referent.
+                                                              When unspecified, "gateway.networking.k8s.io" is inferred.
+                                                              To set the core API group (such as for a "Service" kind referent),
+                                                              Group must be explicitly set to "" (empty string).
+                                                              
+                                                              
+                                                              Support: Core
+                                                            maxLength: 253
+                                                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                                            type: string
+                                                          kind:
+                                                            default: Gateway
+                                                            description: |-
+                                                              Kind is kind of the referent.
+                                                              
+                                                              
+                                                              There are two kinds of parent resources with "Core" support:
+                                                              
+                                                              
+                                                              * Gateway (Gateway conformance profile)
+                                                              * Service (Mesh conformance profile, experimental, ClusterIP Services only)
+                                                              
+                                                              
+                                                              Support for other resources is Implementation-Specific.
+                                                            maxLength: 63
+                                                            minLength: 1
+                                                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                                            type: string
+                                                          name:
+                                                            description: |-
+                                                              Name is the name of the referent.
+                                                              
+                                                              
+                                                              Support: Core
+                                                            maxLength: 253
+                                                            minLength: 1
+                                                            type: string
+                                                          namespace:
+                                                            description: |-
+                                                              Namespace is the namespace of the referent. When unspecified, this refers
+                                                              to the local namespace of the Route.
+                                                              
+                                                              
+                                                              Note that there are specific rules for ParentRefs which cross namespace
+                                                              boundaries. Cross-namespace references are only valid if they are explicitly
+                                                              allowed by something in the namespace they are referring to. For example:
+                                                              Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                                                              generic way to enable any other kind of cross-namespace reference.
+                                                              
+                                                              
+                                                              <gateway:experimental:description>
+                                                              ParentRefs from a Route to a Service in the same namespace are "producer"
+                                                              routes, which apply default routing rules to inbound connections from
+                                                              any namespace to the Service.
+                                                              
+                                                              
+                                                              ParentRefs from a Route to a Service in a different namespace are
+                                                              "consumer" routes, and these routing rules are only applied to outbound
+                                                              connections originating from the same namespace as the Route, for which
+                                                              the intended destination of the connections are a Service targeted as a
+                                                              ParentRef of the Route.
+                                                              </gateway:experimental:description>
+                                                              
+                                                              
+                                                              Support: Core
+                                                            maxLength: 63
+                                                            minLength: 1
+                                                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                            type: string
+                                                          port:
+                                                            description: |-
+                                                              Port is the network port this Route targets. It can be interpreted
+                                                              differently based on the type of parent resource.
+                                                              
+                                                              
+                                                              When the parent resource is a Gateway, this targets all listeners
+                                                              listening on the specified port that also support this kind of Route(and
+                                                              select this Route). It's not recommended to set `Port` unless the
+                                                              networking behaviors specified in a Route must apply to a specific port
+                                                              as opposed to a listener(s) whose port(s) may be changed. When both Port
+                                                              and SectionName are specified, the name and port of the selected listener
+                                                              must match both specified values.
+                                                              
+                                                              
+                                                              <gateway:experimental:description>
+                                                              When the parent resource is a Service, this targets a specific port in the
+                                                              Service spec. When both Port (experimental) and SectionName are specified,
+                                                              the name and port of the selected port must match both specified values.
+                                                              </gateway:experimental:description>
+                                                              
+                                                              
+                                                              Implementations MAY choose to support other parent resources.
+                                                              Implementations supporting other types of parent resources MUST clearly
+                                                              document how/if Port is interpreted.
+                                                              
+                                                              
+                                                              For the purpose of status, an attachment is considered successful as
+                                                              long as the parent resource accepts it partially. For example, Gateway
+                                                              listeners can restrict which Routes can attach to them by Route kind,
+                                                              namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                                                              from the referencing Route, the Route MUST be considered successfully
+                                                              attached. If no Gateway listeners accept attachment from this Route,
+                                                              the Route MUST be considered detached from the Gateway.
+                                                              
+                                                              
+                                                              Support: Extended
+                                                              
+                                                              
+                                                              <gateway:experimental>
+                                                            format: int32
+                                                            maximum: 65535
+                                                            minimum: 1
+                                                            type: integer
+                                                          sectionName:
+                                                            description: |-
+                                                              SectionName is the name of a section within the target resource. In the
+                                                              following resources, SectionName is interpreted as the following:
+                                                              
+                                                              
+                                                              * Gateway: Listener Name. When both Port (experimental) and SectionName
+                                                              are specified, the name and port of the selected listener must match
+                                                              both specified values.
+                                                              * Service: Port Name. When both Port (experimental) and SectionName
+                                                              are specified, the name and port of the selected listener must match
+                                                              both specified values. Note that attaching Routes to Services as Parents
+                                                              is part of experimental Mesh support and is not supported for any other
+                                                              purpose.
+                                                              
+                                                              
+                                                              Implementations MAY choose to support attaching Routes to other resources.
+                                                              If that is the case, they MUST clearly document how SectionName is
+                                                              interpreted.
+                                                              
+                                                              
+                                                              When unspecified (empty string), this will reference the entire resource.
+                                                              For the purpose of status, an attachment is considered successful if at
+                                                              least one section in the parent resource accepts it. For example, Gateway
+                                                              listeners can restrict which Routes can attach to them by Route kind,
+                                                              namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                                                              the referencing Route, the Route MUST be considered successfully
+                                                              attached. If no Gateway listeners accept attachment from this Route, the
+                                                              Route MUST be considered detached from the Gateway.
+                                                              
+                                                              
+                                                              Support: Core
+                                                            maxLength: 253
+                                                            minLength: 1
+                                                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                                            type: string
+                                                        required:
+                                                          - name
+                                                        type: object
+                                                      type: array
+                                                    serviceType:
+                                                      description: |-
+                                                        Optional service type for Kubernetes solver service. Supported values
+                                                        are NodePort or ClusterIP. If unset, defaults to NodePort.
+                                                      type: string
+                                                  type: object
+                                                ingress:
+                                                  description: |-
+                                                    The ingress based HTTP01 challenge solver will solve challenges by
+                                                    creating or modifying Ingress resources in order to route requests for
+                                                    '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are
+                                                    provisioned by cert-manager for each Challenge to be completed.
+                                                  properties:
+                                                    class:
+                                                      description: |-
+                                                        This field configures the annotation `kubernetes.io/ingress.class` when
+                                                        creating Ingress resources to solve ACME challenges that use this
+                                                        challenge solver. Only one of `class`, `name` or `ingressClassName` may
+                                                        be specified.
+                                                      type: string
+                                                    ingressClassName:
+                                                      description: |-
+                                                        This field configures the field `ingressClassName` on the created Ingress
+                                                        resources used to solve ACME challenges that use this challenge solver.
+                                                        This is the recommended way of configuring the ingress class. Only one of
+                                                        `class`, `name` or `ingressClassName` may be specified.
+                                                      type: string
+                                                    ingressTemplate:
+                                                      description: |-
+                                                        Optional ingress template used to configure the ACME challenge solver
+                                                        ingress used for HTTP01 challenges.
+                                                      properties:
+                                                        metadata:
+                                                          description: |-
+                                                            ObjectMeta overrides for the ingress used to solve HTTP01 challenges.
+                                                            Only the 'labels' and 'annotations' fields may be set.
+                                                            If labels or annotations overlap with in-built values, the values here
+                                                            will override the in-built values.
+                                                          properties:
+                                                            annotations:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: Annotations that should be added to the created ACME HTTP01 solver ingress.
+                                                              type: object
+                                                            labels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: Labels that should be added to the created ACME HTTP01 solver ingress.
+                                                              type: object
+                                                          type: object
+                                                      type: object
+                                                    name:
+                                                      description: |-
+                                                        The name of the ingress resource that should have ACME challenge solving
+                                                        routes inserted into it in order to solve HTTP01 challenges.
+                                                        This is typically used in conjunction with ingress controllers like
+                                                        ingress-gce, which maintains a 1:1 mapping between external IPs and
+                                                        ingress resources. Only one of `class`, `name` or `ingressClassName` may
+                                                        be specified.
+                                                      type: string
+                                                    podTemplate:
+                                                      description: |-
+                                                        Optional pod template used to configure the ACME challenge solver pods
+                                                        used for HTTP01 challenges.
+                                                      properties:
+                                                        metadata:
+                                                          description: |-
+                                                            ObjectMeta overrides for the pod used to solve HTTP01 challenges.
+                                                            Only the 'labels' and 'annotations' fields may be set.
+                                                            If labels or annotations overlap with in-built values, the values here
+                                                            will override the in-built values.
+                                                          properties:
+                                                            annotations:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: Annotations that should be added to the create ACME HTTP01 solver pods.
+                                                              type: object
+                                                            labels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                                              type: object
+                                                          type: object
+                                                        spec:
+                                                          description: |-
+                                                            PodSpec defines overrides for the HTTP01 challenge solver pod.
+                                                            Check ACMEChallengeSolverHTTP01IngressPodSpec to find out currently supported fields.
+                                                            All other fields will be ignored.
+                                                          properties:
+                                                            affinity:
+                                                              description: If specified, the pod's scheduling constraints
+                                                              properties:
+                                                                nodeAffinity:
+                                                                  description: Describes node affinity scheduling rules for the pod.
+                                                                  properties:
+                                                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                                                      description: |-
+                                                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                                                        the affinity expressions specified by this field, but it may choose
+                                                                        a node that violates one or more of the expressions. The node that is
+                                                                        most preferred is the one with the greatest sum of weights, i.e.
+                                                                        for each node that meets all of the scheduling requirements (resource
+                                                                        request, requiredDuringScheduling affinity expressions, etc.),
+                                                                        compute a sum by iterating through the elements of this field and adding
+                                                                        "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                                                        node(s) with the highest sum are the most preferred.
+                                                                      items:
+                                                                        description: |-
+                                                                          An empty preferred scheduling term matches all objects with implicit weight 0
+                                                                          (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                                        properties:
+                                                                          preference:
+                                                                            description: A node selector term, associated with the corresponding weight.
+                                                                            properties:
+                                                                              matchExpressions:
+                                                                                description: A list of node selector requirements by node's labels.
+                                                                                items:
+                                                                                  description: |-
+                                                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                                                    that relates the key and values.
+                                                                                  properties:
+                                                                                    key:
+                                                                                      description: The label key that the selector applies to.
+                                                                                      type: string
+                                                                                    operator:
+                                                                                      description: |-
+                                                                                        Represents a key's relationship to a set of values.
+                                                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                                      type: string
+                                                                                    values:
+                                                                                      description: |-
+                                                                                        An array of string values. If the operator is In or NotIn,
+                                                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                                                        array must have a single element, which will be interpreted as an integer.
+                                                                                        This array is replaced during a strategic merge patch.
+                                                                                      items:
+                                                                                        type: string
+                                                                                      type: array
+                                                                                  required:
+                                                                                    - key
+                                                                                    - operator
+                                                                                  type: object
+                                                                                type: array
+                                                                              matchFields:
+                                                                                description: A list of node selector requirements by node's fields.
+                                                                                items:
+                                                                                  description: |-
+                                                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                                                    that relates the key and values.
+                                                                                  properties:
+                                                                                    key:
+                                                                                      description: The label key that the selector applies to.
+                                                                                      type: string
+                                                                                    operator:
+                                                                                      description: |-
+                                                                                        Represents a key's relationship to a set of values.
+                                                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                                      type: string
+                                                                                    values:
+                                                                                      description: |-
+                                                                                        An array of string values. If the operator is In or NotIn,
+                                                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                                                        array must have a single element, which will be interpreted as an integer.
+                                                                                        This array is replaced during a strategic merge patch.
+                                                                                      items:
+                                                                                        type: string
+                                                                                      type: array
+                                                                                  required:
+                                                                                    - key
+                                                                                    - operator
+                                                                                  type: object
+                                                                                type: array
+                                                                            type: object
+                                                                            x-kubernetes-map-type: atomic
+                                                                          weight:
+                                                                            description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                                            format: int32
+                                                                            type: integer
+                                                                        required:
+                                                                          - preference
+                                                                          - weight
+                                                                        type: object
+                                                                      type: array
+                                                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                                                      description: |-
+                                                                        If the affinity requirements specified by this field are not met at
+                                                                        scheduling time, the pod will not be scheduled onto the node.
+                                                                        If the affinity requirements specified by this field cease to be met
+                                                                        at some point during pod execution (e.g. due to an update), the system
+                                                                        may or may not try to eventually evict the pod from its node.
+                                                                      properties:
+                                                                        nodeSelectorTerms:
+                                                                          description: Required. A list of node selector terms. The terms are ORed.
+                                                                          items:
+                                                                            description: |-
+                                                                              A null or empty node selector term matches no objects. The requirements of
+                                                                              them are ANDed.
+                                                                              The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                                            properties:
+                                                                              matchExpressions:
+                                                                                description: A list of node selector requirements by node's labels.
+                                                                                items:
+                                                                                  description: |-
+                                                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                                                    that relates the key and values.
+                                                                                  properties:
+                                                                                    key:
+                                                                                      description: The label key that the selector applies to.
+                                                                                      type: string
+                                                                                    operator:
+                                                                                      description: |-
+                                                                                        Represents a key's relationship to a set of values.
+                                                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                                      type: string
+                                                                                    values:
+                                                                                      description: |-
+                                                                                        An array of string values. If the operator is In or NotIn,
+                                                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                                                        array must have a single element, which will be interpreted as an integer.
+                                                                                        This array is replaced during a strategic merge patch.
+                                                                                      items:
+                                                                                        type: string
+                                                                                      type: array
+                                                                                  required:
+                                                                                    - key
+                                                                                    - operator
+                                                                                  type: object
+                                                                                type: array
+                                                                              matchFields:
+                                                                                description: A list of node selector requirements by node's fields.
+                                                                                items:
+                                                                                  description: |-
+                                                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                                                    that relates the key and values.
+                                                                                  properties:
+                                                                                    key:
+                                                                                      description: The label key that the selector applies to.
+                                                                                      type: string
+                                                                                    operator:
+                                                                                      description: |-
+                                                                                        Represents a key's relationship to a set of values.
+                                                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                                      type: string
+                                                                                    values:
+                                                                                      description: |-
+                                                                                        An array of string values. If the operator is In or NotIn,
+                                                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                                                        array must have a single element, which will be interpreted as an integer.
+                                                                                        This array is replaced during a strategic merge patch.
+                                                                                      items:
+                                                                                        type: string
+                                                                                      type: array
+                                                                                  required:
+                                                                                    - key
+                                                                                    - operator
+                                                                                  type: object
+                                                                                type: array
+                                                                            type: object
+                                                                            x-kubernetes-map-type: atomic
+                                                                          type: array
+                                                                      required:
+                                                                        - nodeSelectorTerms
+                                                                      type: object
+                                                                      x-kubernetes-map-type: atomic
+                                                                  type: object
+                                                                podAffinity:
+                                                                  description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                                                  properties:
+                                                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                                                      description: |-
+                                                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                                                        the affinity expressions specified by this field, but it may choose
+                                                                        a node that violates one or more of the expressions. The node that is
+                                                                        most preferred is the one with the greatest sum of weights, i.e.
+                                                                        for each node that meets all of the scheduling requirements (resource
+                                                                        request, requiredDuringScheduling affinity expressions, etc.),
+                                                                        compute a sum by iterating through the elements of this field and adding
+                                                                        "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                                        node(s) with the highest sum are the most preferred.
+                                                                      items:
+                                                                        description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                                        properties:
+                                                                          podAffinityTerm:
+                                                                            description: Required. A pod affinity term, associated with the corresponding weight.
+                                                                            properties:
+                                                                              labelSelector:
+                                                                                description: |-
+                                                                                  A label query over a set of resources, in this case pods.
+                                                                                  If it's null, this PodAffinityTerm matches with no Pods.
+                                                                                properties:
+                                                                                  matchExpressions:
+                                                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                    items:
+                                                                                      description: |-
+                                                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                        relates the key and values.
+                                                                                      properties:
+                                                                                        key:
+                                                                                          description: key is the label key that the selector applies to.
+                                                                                          type: string
+                                                                                        operator:
+                                                                                          description: |-
+                                                                                            operator represents a key's relationship to a set of values.
+                                                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                          type: string
+                                                                                        values:
+                                                                                          description: |-
+                                                                                            values is an array of string values. If the operator is In or NotIn,
+                                                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                            the values array must be empty. This array is replaced during a strategic
+                                                                                            merge patch.
+                                                                                          items:
+                                                                                            type: string
+                                                                                          type: array
+                                                                                      required:
+                                                                                        - key
+                                                                                        - operator
+                                                                                      type: object
+                                                                                    type: array
+                                                                                  matchLabels:
+                                                                                    additionalProperties:
+                                                                                      type: string
+                                                                                    description: |-
+                                                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                    type: object
+                                                                                type: object
+                                                                                x-kubernetes-map-type: atomic
+                                                                              matchLabelKeys:
+                                                                                description: |-
+                                                                                  MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                                  be taken into consideration. The keys are used to lookup values from the
+                                                                                  incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                                                                  to select the group of existing pods which pods will be taken into consideration
+                                                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                                  pod labels will be ignored. The default value is empty.
+                                                                                  The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                                                                  Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                                items:
+                                                                                  type: string
+                                                                                type: array
+                                                                                x-kubernetes-list-type: atomic
+                                                                              mismatchLabelKeys:
+                                                                                description: |-
+                                                                                  MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                                  be taken into consideration. The keys are used to lookup values from the
+                                                                                  incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                                                                  to select the group of existing pods which pods will be taken into consideration
+                                                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                                  pod labels will be ignored. The default value is empty.
+                                                                                  The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                                                                  Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                                items:
+                                                                                  type: string
+                                                                                type: array
+                                                                                x-kubernetes-list-type: atomic
+                                                                              namespaceSelector:
+                                                                                description: |-
+                                                                                  A label query over the set of namespaces that the term applies to.
+                                                                                  The term is applied to the union of the namespaces selected by this field
+                                                                                  and the ones listed in the namespaces field.
+                                                                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                                                                  An empty selector ({}) matches all namespaces.
+                                                                                properties:
+                                                                                  matchExpressions:
+                                                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                    items:
+                                                                                      description: |-
+                                                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                        relates the key and values.
+                                                                                      properties:
+                                                                                        key:
+                                                                                          description: key is the label key that the selector applies to.
+                                                                                          type: string
+                                                                                        operator:
+                                                                                          description: |-
+                                                                                            operator represents a key's relationship to a set of values.
+                                                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                          type: string
+                                                                                        values:
+                                                                                          description: |-
+                                                                                            values is an array of string values. If the operator is In or NotIn,
+                                                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                            the values array must be empty. This array is replaced during a strategic
+                                                                                            merge patch.
+                                                                                          items:
+                                                                                            type: string
+                                                                                          type: array
+                                                                                      required:
+                                                                                        - key
+                                                                                        - operator
+                                                                                      type: object
+                                                                                    type: array
+                                                                                  matchLabels:
+                                                                                    additionalProperties:
+                                                                                      type: string
+                                                                                    description: |-
+                                                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                    type: object
+                                                                                type: object
+                                                                                x-kubernetes-map-type: atomic
+                                                                              namespaces:
+                                                                                description: |-
+                                                                                  namespaces specifies a static list of namespace names that the term applies to.
+                                                                                  The term is applied to the union of the namespaces listed in this field
+                                                                                  and the ones selected by namespaceSelector.
+                                                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                                                items:
+                                                                                  type: string
+                                                                                type: array
+                                                                              topologyKey:
+                                                                                description: |-
+                                                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                                  selected pods is running.
+                                                                                  Empty topologyKey is not allowed.
+                                                                                type: string
+                                                                            required:
+                                                                              - topologyKey
+                                                                            type: object
+                                                                          weight:
+                                                                            description: |-
+                                                                              weight associated with matching the corresponding podAffinityTerm,
+                                                                              in the range 1-100.
+                                                                            format: int32
+                                                                            type: integer
+                                                                        required:
+                                                                          - podAffinityTerm
+                                                                          - weight
+                                                                        type: object
+                                                                      type: array
+                                                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                                                      description: |-
+                                                                        If the affinity requirements specified by this field are not met at
+                                                                        scheduling time, the pod will not be scheduled onto the node.
+                                                                        If the affinity requirements specified by this field cease to be met
+                                                                        at some point during pod execution (e.g. due to a pod label update), the
+                                                                        system may or may not try to eventually evict the pod from its node.
+                                                                        When there are multiple elements, the lists of nodes corresponding to each
+                                                                        podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                                      items:
+                                                                        description: |-
+                                                                          Defines a set of pods (namely those matching the labelSelector
+                                                                          relative to the given namespace(s)) that this pod should be
+                                                                          co-located (affinity) or not co-located (anti-affinity) with,
+                                                                          where co-located is defined as running on a node whose value of
+                                                                          the label with key <topologyKey> matches that of any node on which
+                                                                          a pod of the set of pods is running
+                                                                        properties:
+                                                                          labelSelector:
+                                                                            description: |-
+                                                                              A label query over a set of resources, in this case pods.
+                                                                              If it's null, this PodAffinityTerm matches with no Pods.
+                                                                            properties:
+                                                                              matchExpressions:
+                                                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                items:
+                                                                                  description: |-
+                                                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                    relates the key and values.
+                                                                                  properties:
+                                                                                    key:
+                                                                                      description: key is the label key that the selector applies to.
+                                                                                      type: string
+                                                                                    operator:
+                                                                                      description: |-
+                                                                                        operator represents a key's relationship to a set of values.
+                                                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                      type: string
+                                                                                    values:
+                                                                                      description: |-
+                                                                                        values is an array of string values. If the operator is In or NotIn,
+                                                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                        the values array must be empty. This array is replaced during a strategic
+                                                                                        merge patch.
+                                                                                      items:
+                                                                                        type: string
+                                                                                      type: array
+                                                                                  required:
+                                                                                    - key
+                                                                                    - operator
+                                                                                  type: object
+                                                                                type: array
+                                                                              matchLabels:
+                                                                                additionalProperties:
+                                                                                  type: string
+                                                                                description: |-
+                                                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                type: object
+                                                                            type: object
+                                                                            x-kubernetes-map-type: atomic
+                                                                          matchLabelKeys:
+                                                                            description: |-
+                                                                              MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                              be taken into consideration. The keys are used to lookup values from the
+                                                                              incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                                                              to select the group of existing pods which pods will be taken into consideration
+                                                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                              pod labels will be ignored. The default value is empty.
+                                                                              The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                                                              Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                                              This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                            items:
+                                                                              type: string
+                                                                            type: array
+                                                                            x-kubernetes-list-type: atomic
+                                                                          mismatchLabelKeys:
+                                                                            description: |-
+                                                                              MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                              be taken into consideration. The keys are used to lookup values from the
+                                                                              incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                                                              to select the group of existing pods which pods will be taken into consideration
+                                                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                              pod labels will be ignored. The default value is empty.
+                                                                              The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                                                              Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                                              This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                            items:
+                                                                              type: string
+                                                                            type: array
+                                                                            x-kubernetes-list-type: atomic
+                                                                          namespaceSelector:
+                                                                            description: |-
+                                                                              A label query over the set of namespaces that the term applies to.
+                                                                              The term is applied to the union of the namespaces selected by this field
+                                                                              and the ones listed in the namespaces field.
+                                                                              null selector and null or empty namespaces list means "this pod's namespace".
+                                                                              An empty selector ({}) matches all namespaces.
+                                                                            properties:
+                                                                              matchExpressions:
+                                                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                items:
+                                                                                  description: |-
+                                                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                    relates the key and values.
+                                                                                  properties:
+                                                                                    key:
+                                                                                      description: key is the label key that the selector applies to.
+                                                                                      type: string
+                                                                                    operator:
+                                                                                      description: |-
+                                                                                        operator represents a key's relationship to a set of values.
+                                                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                      type: string
+                                                                                    values:
+                                                                                      description: |-
+                                                                                        values is an array of string values. If the operator is In or NotIn,
+                                                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                        the values array must be empty. This array is replaced during a strategic
+                                                                                        merge patch.
+                                                                                      items:
+                                                                                        type: string
+                                                                                      type: array
+                                                                                  required:
+                                                                                    - key
+                                                                                    - operator
+                                                                                  type: object
+                                                                                type: array
+                                                                              matchLabels:
+                                                                                additionalProperties:
+                                                                                  type: string
+                                                                                description: |-
+                                                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                type: object
+                                                                            type: object
+                                                                            x-kubernetes-map-type: atomic
+                                                                          namespaces:
+                                                                            description: |-
+                                                                              namespaces specifies a static list of namespace names that the term applies to.
+                                                                              The term is applied to the union of the namespaces listed in this field
+                                                                              and the ones selected by namespaceSelector.
+                                                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                                            items:
+                                                                              type: string
+                                                                            type: array
+                                                                          topologyKey:
+                                                                            description: |-
+                                                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                              whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                              selected pods is running.
+                                                                              Empty topologyKey is not allowed.
+                                                                            type: string
+                                                                        required:
+                                                                          - topologyKey
+                                                                        type: object
+                                                                      type: array
+                                                                  type: object
+                                                                podAntiAffinity:
+                                                                  description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                                                  properties:
+                                                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                                                      description: |-
+                                                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                                                        the anti-affinity expressions specified by this field, but it may choose
+                                                                        a node that violates one or more of the expressions. The node that is
+                                                                        most preferred is the one with the greatest sum of weights, i.e.
+                                                                        for each node that meets all of the scheduling requirements (resource
+                                                                        request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                                                        compute a sum by iterating through the elements of this field and adding
+                                                                        "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                                        node(s) with the highest sum are the most preferred.
+                                                                      items:
+                                                                        description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                                        properties:
+                                                                          podAffinityTerm:
+                                                                            description: Required. A pod affinity term, associated with the corresponding weight.
+                                                                            properties:
+                                                                              labelSelector:
+                                                                                description: |-
+                                                                                  A label query over a set of resources, in this case pods.
+                                                                                  If it's null, this PodAffinityTerm matches with no Pods.
+                                                                                properties:
+                                                                                  matchExpressions:
+                                                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                    items:
+                                                                                      description: |-
+                                                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                        relates the key and values.
+                                                                                      properties:
+                                                                                        key:
+                                                                                          description: key is the label key that the selector applies to.
+                                                                                          type: string
+                                                                                        operator:
+                                                                                          description: |-
+                                                                                            operator represents a key's relationship to a set of values.
+                                                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                          type: string
+                                                                                        values:
+                                                                                          description: |-
+                                                                                            values is an array of string values. If the operator is In or NotIn,
+                                                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                            the values array must be empty. This array is replaced during a strategic
+                                                                                            merge patch.
+                                                                                          items:
+                                                                                            type: string
+                                                                                          type: array
+                                                                                      required:
+                                                                                        - key
+                                                                                        - operator
+                                                                                      type: object
+                                                                                    type: array
+                                                                                  matchLabels:
+                                                                                    additionalProperties:
+                                                                                      type: string
+                                                                                    description: |-
+                                                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                    type: object
+                                                                                type: object
+                                                                                x-kubernetes-map-type: atomic
+                                                                              matchLabelKeys:
+                                                                                description: |-
+                                                                                  MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                                  be taken into consideration. The keys are used to lookup values from the
+                                                                                  incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                                                                  to select the group of existing pods which pods will be taken into consideration
+                                                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                                  pod labels will be ignored. The default value is empty.
+                                                                                  The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                                                                  Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                                items:
+                                                                                  type: string
+                                                                                type: array
+                                                                                x-kubernetes-list-type: atomic
+                                                                              mismatchLabelKeys:
+                                                                                description: |-
+                                                                                  MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                                  be taken into consideration. The keys are used to lookup values from the
+                                                                                  incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                                                                  to select the group of existing pods which pods will be taken into consideration
+                                                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                                  pod labels will be ignored. The default value is empty.
+                                                                                  The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                                                                  Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                                items:
+                                                                                  type: string
+                                                                                type: array
+                                                                                x-kubernetes-list-type: atomic
+                                                                              namespaceSelector:
+                                                                                description: |-
+                                                                                  A label query over the set of namespaces that the term applies to.
+                                                                                  The term is applied to the union of the namespaces selected by this field
+                                                                                  and the ones listed in the namespaces field.
+                                                                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                                                                  An empty selector ({}) matches all namespaces.
+                                                                                properties:
+                                                                                  matchExpressions:
+                                                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                    items:
+                                                                                      description: |-
+                                                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                        relates the key and values.
+                                                                                      properties:
+                                                                                        key:
+                                                                                          description: key is the label key that the selector applies to.
+                                                                                          type: string
+                                                                                        operator:
+                                                                                          description: |-
+                                                                                            operator represents a key's relationship to a set of values.
+                                                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                          type: string
+                                                                                        values:
+                                                                                          description: |-
+                                                                                            values is an array of string values. If the operator is In or NotIn,
+                                                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                            the values array must be empty. This array is replaced during a strategic
+                                                                                            merge patch.
+                                                                                          items:
+                                                                                            type: string
+                                                                                          type: array
+                                                                                      required:
+                                                                                        - key
+                                                                                        - operator
+                                                                                      type: object
+                                                                                    type: array
+                                                                                  matchLabels:
+                                                                                    additionalProperties:
+                                                                                      type: string
+                                                                                    description: |-
+                                                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                    type: object
+                                                                                type: object
+                                                                                x-kubernetes-map-type: atomic
+                                                                              namespaces:
+                                                                                description: |-
+                                                                                  namespaces specifies a static list of namespace names that the term applies to.
+                                                                                  The term is applied to the union of the namespaces listed in this field
+                                                                                  and the ones selected by namespaceSelector.
+                                                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                                                items:
+                                                                                  type: string
+                                                                                type: array
+                                                                              topologyKey:
+                                                                                description: |-
+                                                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                                  selected pods is running.
+                                                                                  Empty topologyKey is not allowed.
+                                                                                type: string
+                                                                            required:
+                                                                              - topologyKey
+                                                                            type: object
+                                                                          weight:
+                                                                            description: |-
+                                                                              weight associated with matching the corresponding podAffinityTerm,
+                                                                              in the range 1-100.
+                                                                            format: int32
+                                                                            type: integer
+                                                                        required:
+                                                                          - podAffinityTerm
+                                                                          - weight
+                                                                        type: object
+                                                                      type: array
+                                                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                                                      description: |-
+                                                                        If the anti-affinity requirements specified by this field are not met at
+                                                                        scheduling time, the pod will not be scheduled onto the node.
+                                                                        If the anti-affinity requirements specified by this field cease to be met
+                                                                        at some point during pod execution (e.g. due to a pod label update), the
+                                                                        system may or may not try to eventually evict the pod from its node.
+                                                                        When there are multiple elements, the lists of nodes corresponding to each
+                                                                        podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                                      items:
+                                                                        description: |-
+                                                                          Defines a set of pods (namely those matching the labelSelector
+                                                                          relative to the given namespace(s)) that this pod should be
+                                                                          co-located (affinity) or not co-located (anti-affinity) with,
+                                                                          where co-located is defined as running on a node whose value of
+                                                                          the label with key <topologyKey> matches that of any node on which
+                                                                          a pod of the set of pods is running
+                                                                        properties:
+                                                                          labelSelector:
+                                                                            description: |-
+                                                                              A label query over a set of resources, in this case pods.
+                                                                              If it's null, this PodAffinityTerm matches with no Pods.
+                                                                            properties:
+                                                                              matchExpressions:
+                                                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                items:
+                                                                                  description: |-
+                                                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                    relates the key and values.
+                                                                                  properties:
+                                                                                    key:
+                                                                                      description: key is the label key that the selector applies to.
+                                                                                      type: string
+                                                                                    operator:
+                                                                                      description: |-
+                                                                                        operator represents a key's relationship to a set of values.
+                                                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                      type: string
+                                                                                    values:
+                                                                                      description: |-
+                                                                                        values is an array of string values. If the operator is In or NotIn,
+                                                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                        the values array must be empty. This array is replaced during a strategic
+                                                                                        merge patch.
+                                                                                      items:
+                                                                                        type: string
+                                                                                      type: array
+                                                                                  required:
+                                                                                    - key
+                                                                                    - operator
+                                                                                  type: object
+                                                                                type: array
+                                                                              matchLabels:
+                                                                                additionalProperties:
+                                                                                  type: string
+                                                                                description: |-
+                                                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                type: object
+                                                                            type: object
+                                                                            x-kubernetes-map-type: atomic
+                                                                          matchLabelKeys:
+                                                                            description: |-
+                                                                              MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                              be taken into consideration. The keys are used to lookup values from the
+                                                                              incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                                                              to select the group of existing pods which pods will be taken into consideration
+                                                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                              pod labels will be ignored. The default value is empty.
+                                                                              The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                                                              Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                                              This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                            items:
+                                                                              type: string
+                                                                            type: array
+                                                                            x-kubernetes-list-type: atomic
+                                                                          mismatchLabelKeys:
+                                                                            description: |-
+                                                                              MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                              be taken into consideration. The keys are used to lookup values from the
+                                                                              incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                                                              to select the group of existing pods which pods will be taken into consideration
+                                                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                              pod labels will be ignored. The default value is empty.
+                                                                              The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                                                              Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                                              This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                            items:
+                                                                              type: string
+                                                                            type: array
+                                                                            x-kubernetes-list-type: atomic
+                                                                          namespaceSelector:
+                                                                            description: |-
+                                                                              A label query over the set of namespaces that the term applies to.
+                                                                              The term is applied to the union of the namespaces selected by this field
+                                                                              and the ones listed in the namespaces field.
+                                                                              null selector and null or empty namespaces list means "this pod's namespace".
+                                                                              An empty selector ({}) matches all namespaces.
+                                                                            properties:
+                                                                              matchExpressions:
+                                                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                items:
+                                                                                  description: |-
+                                                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                    relates the key and values.
+                                                                                  properties:
+                                                                                    key:
+                                                                                      description: key is the label key that the selector applies to.
+                                                                                      type: string
+                                                                                    operator:
+                                                                                      description: |-
+                                                                                        operator represents a key's relationship to a set of values.
+                                                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                      type: string
+                                                                                    values:
+                                                                                      description: |-
+                                                                                        values is an array of string values. If the operator is In or NotIn,
+                                                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                        the values array must be empty. This array is replaced during a strategic
+                                                                                        merge patch.
+                                                                                      items:
+                                                                                        type: string
+                                                                                      type: array
+                                                                                  required:
+                                                                                    - key
+                                                                                    - operator
+                                                                                  type: object
+                                                                                type: array
+                                                                              matchLabels:
+                                                                                additionalProperties:
+                                                                                  type: string
+                                                                                description: |-
+                                                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                type: object
+                                                                            type: object
+                                                                            x-kubernetes-map-type: atomic
+                                                                          namespaces:
+                                                                            description: |-
+                                                                              namespaces specifies a static list of namespace names that the term applies to.
+                                                                              The term is applied to the union of the namespaces listed in this field
+                                                                              and the ones selected by namespaceSelector.
+                                                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                                            items:
+                                                                              type: string
+                                                                            type: array
+                                                                          topologyKey:
+                                                                            description: |-
+                                                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                              whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                              selected pods is running.
+                                                                              Empty topologyKey is not allowed.
+                                                                            type: string
+                                                                        required:
+                                                                          - topologyKey
+                                                                        type: object
+                                                                      type: array
+                                                                  type: object
+                                                              type: object
+                                                            imagePullSecrets:
+                                                              description: If specified, the pod's imagePullSecrets
+                                                              items:
+                                                                description: |-
+                                                                  LocalObjectReference contains enough information to let you locate the
+                                                                  referenced object inside the same namespace.
+                                                                properties:
+                                                                  name:
+                                                                    description: |-
+                                                                      Name of the referent.
+                                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                      TODO: Add other useful fields. apiVersion, kind, uid?
+                                                                    type: string
+                                                                type: object
+                                                                x-kubernetes-map-type: atomic
+                                                              type: array
+                                                            nodeSelector:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: |-
+                                                                NodeSelector is a selector which must be true for the pod to fit on a node.
+                                                                Selector which must match a node's labels for the pod to be scheduled on that node.
+                                                                More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                                                              type: object
+                                                            priorityClassName:
+                                                              description: If specified, the pod's priorityClassName.
+                                                              type: string
+                                                            serviceAccountName:
+                                                              description: If specified, the pod's service account
+                                                              type: string
+                                                            tolerations:
+                                                              description: If specified, the pod's tolerations.
+                                                              items:
+                                                                description: |-
+                                                                  The pod this Toleration is attached to tolerates any taint that matches
+                                                                  the triple <key,value,effect> using the matching operator <operator>.
+                                                                properties:
+                                                                  effect:
+                                                                    description: |-
+                                                                      Effect indicates the taint effect to match. Empty means match all taint effects.
+                                                                      When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                                                    type: string
+                                                                  key:
+                                                                    description: |-
+                                                                      Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                                                      If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Operator represents a key's relationship to the value.
+                                                                      Valid operators are Exists and Equal. Defaults to Equal.
+                                                                      Exists is equivalent to wildcard for value, so that a pod can
+                                                                      tolerate all taints of a particular category.
+                                                                    type: string
+                                                                  tolerationSeconds:
+                                                                    description: |-
+                                                                      TolerationSeconds represents the period of time the toleration (which must be
+                                                                      of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                                                      it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                                                      negative values will be treated as 0 (evict immediately) by the system.
+                                                                    format: int64
+                                                                    type: integer
+                                                                  value:
+                                                                    description: |-
+                                                                      Value is the taint value the toleration matches to.
+                                                                      If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                                                    type: string
+                                                                type: object
+                                                              type: array
+                                                          type: object
+                                                      type: object
+                                                    serviceType:
+                                                      description: |-
+                                                        Optional service type for Kubernetes solver service. Supported values
+                                                        are NodePort or ClusterIP. If unset, defaults to NodePort.
+                                                      type: string
+                                                  type: object
+                                              type: object
+                                            selector:
+                                              description: |-
+                                                Selector selects a set of DNSNames on the Certificate resource that
+                                                should be solved using this challenge solver.
+                                                If not specified, the solver will be treated as the 'default' solver
+                                                with the lowest priority, i.e. if any other solver has a more specific
+                                                match, it will be used instead.
+                                              properties:
+                                                dnsNames:
+                                                  description: |-
+                                                    List of DNSNames that this solver will be used to solve.
+                                                    If specified and a match is found, a dnsNames selector will take
+                                                    precedence over a dnsZones selector.
+                                                    If multiple solvers match with the same dnsNames value, the solver
+                                                    with the most matching labels in matchLabels will be selected.
+                                                    If neither has more matches, the solver defined earlier in the list
+                                                    will be selected.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                dnsZones:
+                                                  description: |-
+                                                    List of DNSZones that this solver will be used to solve.
+                                                    The most specific DNS zone match specified here will take precedence
+                                                    over other DNS zone matches, so a solver specifying sys.example.com
+                                                    will be selected over one specifying example.com for the domain
+                                                    www.sys.example.com.
+                                                    If multiple solvers match with the same dnsZones value, the solver
+                                                    with the most matching labels in matchLabels will be selected.
+                                                    If neither has more matches, the solver defined earlier in the list
+                                                    will be selected.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    A label selector that is used to refine the set of certificate's that
+                                                    this challenge solver will apply to.
+                                                  type: object
+                                              type: object
+                                          type: object
+                                        type: array
                                     required:
-                                    - patch
+                                      - privateKeySecretRef
+                                      - server
                                     type: object
-                                  type: array
-                              type: object
-                          required:
-                          - url
-                          type: object
-                        name:
-                          type: string
-                        namespace:
-                          type: string
-                      required:
-                      - dryRun
-                      - enabled
-                      - kind
-                      - name
+                                  ca:
+                                    description: |-
+                                      CA configures this issuer to sign certificates using a signing CA keypair
+                                      stored in a Secret resource.
+                                      This is used to build internal PKIs that are managed by cert-manager.
+                                    properties:
+                                      crlDistributionPoints:
+                                        description: |-
+                                          The CRL distribution points is an X.509 v3 certificate extension which identifies
+                                          the location of the CRL from which the revocation of this certificate can be checked.
+                                          If not set, certificates will be issued without distribution points set.
+                                        items:
+                                          type: string
+                                        type: array
+                                      issuingCertificateURLs:
+                                        description: |-
+                                          IssuingCertificateURLs is a list of URLs which this issuer should embed into certificates
+                                          it creates. See https://www.rfc-editor.org/rfc/rfc5280#section-4.2.2.1 for more details.
+                                          As an example, such a URL might be "http://ca.domain.com/ca.crt".
+                                        items:
+                                          type: string
+                                        type: array
+                                      ocspServers:
+                                        description: |-
+                                          The OCSP server list is an X.509 v3 extension that defines a list of
+                                          URLs of OCSP responders. The OCSP responders can be queried for the
+                                          revocation status of an issued certificate. If not set, the
+                                          certificate will be issued with no OCSP servers set. For example, an
+                                          OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                                        items:
+                                          type: string
+                                        type: array
+                                      secretName:
+                                        description: |-
+                                          SecretName is the name of the secret used to sign Certificates issued
+                                          by this Issuer.
+                                        type: string
+                                    required:
+                                      - secretName
+                                    type: object
+                                  selfSigned:
+                                    description: |-
+                                      SelfSigned configures this issuer to 'self sign' certificates using the
+                                      private key used to create the CertificateRequest object.
+                                    properties:
+                                      crlDistributionPoints:
+                                        description: |-
+                                          The CRL distribution points is an X.509 v3 certificate extension which identifies
+                                          the location of the CRL from which the revocation of this certificate can be checked.
+                                          If not set certificate will be issued without CDP. Values are strings.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  vault:
+                                    description: |-
+                                      Vault configures this issuer to sign certificates using a HashiCorp Vault
+                                      PKI backend.
+                                    properties:
+                                      auth:
+                                        description: Auth configures how cert-manager authenticates with the Vault server.
+                                        properties:
+                                          appRole:
+                                            description: |-
+                                              AppRole authenticates with Vault using the App Role auth mechanism,
+                                              with the role and secret stored in a Kubernetes Secret resource.
+                                            properties:
+                                              path:
+                                                description: |-
+                                                  Path where the App Role authentication backend is mounted in Vault, e.g:
+                                                  "approle"
+                                                type: string
+                                              roleId:
+                                                description: |-
+                                                  RoleID configured in the App Role authentication backend when setting
+                                                  up the authentication backend in Vault.
+                                                type: string
+                                              secretRef:
+                                                description: |-
+                                                  Reference to a key in a Secret that contains the App Role secret used
+                                                  to authenticate with Vault.
+                                                  The `key` field must be specified and denotes which entry within the Secret
+                                                  resource is used as the app role secret.
+                                                properties:
+                                                  key:
+                                                    description: |-
+                                                      The key of the entry in the Secret resource's `data` field to be used.
+                                                      Some instances of this field may be defaulted, in others it may be
+                                                      required.
+                                                    type: string
+                                                  name:
+                                                    description: |-
+                                                      Name of the resource being referred to.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                required:
+                                                  - name
+                                                type: object
+                                            required:
+                                              - path
+                                              - roleId
+                                              - secretRef
+                                            type: object
+                                          kubernetes:
+                                            description: |-
+                                              Kubernetes authenticates with Vault by passing the ServiceAccount
+                                              token stored in the named Secret resource to the Vault server.
+                                            properties:
+                                              mountPath:
+                                                description: |-
+                                                  The Vault mountPath here is the mount path to use when authenticating with
+                                                  Vault. For example, setting a value to `/v1/auth/foo`, will use the path
+                                                  `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the
+                                                  default value "/v1/auth/kubernetes" will be used.
+                                                type: string
+                                              role:
+                                                description: |-
+                                                  A required field containing the Vault Role to assume. A Role binds a
+                                                  Kubernetes ServiceAccount with a set of Vault policies.
+                                                type: string
+                                              secretRef:
+                                                description: |-
+                                                  The required Secret field containing a Kubernetes ServiceAccount JWT used
+                                                  for authenticating with Vault. Use of 'ambient credentials' is not
+                                                  supported.
+                                                properties:
+                                                  key:
+                                                    description: |-
+                                                      The key of the entry in the Secret resource's `data` field to be used.
+                                                      Some instances of this field may be defaulted, in others it may be
+                                                      required.
+                                                    type: string
+                                                  name:
+                                                    description: |-
+                                                      Name of the resource being referred to.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                required:
+                                                  - name
+                                                type: object
+                                              serviceAccountRef:
+                                                description: |-
+                                                  A reference to a service account that will be used to request a bound
+                                                  token (also known as "projected token"). Compared to using "secretRef",
+                                                  using this field means that you don't rely on statically bound tokens. To
+                                                  use this field, you must configure an RBAC rule to let cert-manager
+                                                  request a token.
+                                                properties:
+                                                  name:
+                                                    description: Name of the ServiceAccount used to request a token.
+                                                    type: string
+                                                required:
+                                                  - name
+                                                type: object
+                                            required:
+                                              - role
+                                            type: object
+                                          tokenSecretRef:
+                                            description: TokenSecretRef authenticates with Vault by presenting a token.
+                                            properties:
+                                              key:
+                                                description: |-
+                                                  The key of the entry in the Secret resource's `data` field to be used.
+                                                  Some instances of this field may be defaulted, in others it may be
+                                                  required.
+                                                type: string
+                                              name:
+                                                description: |-
+                                                  Name of the resource being referred to.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                            required:
+                                              - name
+                                            type: object
+                                        type: object
+                                      caBundle:
+                                        description: |-
+                                          Base64-encoded bundle of PEM CAs which will be used to validate the certificate
+                                          chain presented by Vault. Only used if using HTTPS to connect to Vault and
+                                          ignored for HTTP connections.
+                                          Mutually exclusive with CABundleSecretRef.
+                                          If neither CABundle nor CABundleSecretRef are defined, the certificate bundle in
+                                          the cert-manager controller container is used to validate the TLS connection.
+                                        format: byte
+                                        type: string
+                                      caBundleSecretRef:
+                                        description: |-
+                                          Reference to a Secret containing a bundle of PEM-encoded CAs to use when
+                                          verifying the certificate chain presented by Vault when using HTTPS.
+                                          Mutually exclusive with CABundle.
+                                          If neither CABundle nor CABundleSecretRef are defined, the certificate bundle in
+                                          the cert-manager controller container is used to validate the TLS connection.
+                                          If no key for the Secret is specified, cert-manager will default to 'ca.crt'.
+                                        properties:
+                                          key:
+                                            description: |-
+                                              The key of the entry in the Secret resource's `data` field to be used.
+                                              Some instances of this field may be defaulted, in others it may be
+                                              required.
+                                            type: string
+                                          name:
+                                            description: |-
+                                              Name of the resource being referred to.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                        required:
+                                          - name
+                                        type: object
+                                      namespace:
+                                        description: |-
+                                          Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1"
+                                          More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces
+                                        type: string
+                                      path:
+                                        description: |-
+                                          Path is the mount path of the Vault PKI backend's `sign` endpoint, e.g:
+                                          "my_pki_mount/sign/my-role-name".
+                                        type: string
+                                      server:
+                                        description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                                        type: string
+                                    required:
+                                      - auth
+                                      - path
+                                      - server
+                                    type: object
+                                  venafi:
+                                    description: |-
+                                      Venafi configures this issuer to sign certificates using a Venafi TPP
+                                      or Venafi Cloud policy zone.
+                                    properties:
+                                      cloud:
+                                        description: |-
+                                          Cloud specifies the Venafi cloud configuration settings.
+                                          Only one of TPP or Cloud may be specified.
+                                        properties:
+                                          apiTokenSecretRef:
+                                            description: APITokenSecretRef is a secret key selector for the Venafi Cloud API token.
+                                            properties:
+                                              key:
+                                                description: |-
+                                                  The key of the entry in the Secret resource's `data` field to be used.
+                                                  Some instances of this field may be defaulted, in others it may be
+                                                  required.
+                                                type: string
+                                              name:
+                                                description: |-
+                                                  Name of the resource being referred to.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                            required:
+                                              - name
+                                            type: object
+                                          url:
+                                            description: |-
+                                              URL is the base URL for Venafi Cloud.
+                                              Defaults to "https://api.venafi.cloud/v1".
+                                            type: string
+                                        required:
+                                          - apiTokenSecretRef
+                                        type: object
+                                      tpp:
+                                        description: |-
+                                          TPP specifies Trust Protection Platform configuration settings.
+                                          Only one of TPP or Cloud may be specified.
+                                        properties:
+                                          caBundle:
+                                            description: |-
+                                              Base64-encoded bundle of PEM CAs which will be used to validate the certificate
+                                              chain presented by the TPP server. Only used if using HTTPS; ignored for HTTP.
+                                              If undefined, the certificate bundle in the cert-manager controller container
+                                              is used to validate the chain.
+                                            format: byte
+                                            type: string
+                                          credentialsRef:
+                                            description: |-
+                                              CredentialsRef is a reference to a Secret containing the username and
+                                              password for the TPP server.
+                                              The secret must contain two keys, 'username' and 'password'.
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  Name of the resource being referred to.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                            required:
+                                              - name
+                                            type: object
+                                          url:
+                                            description: |-
+                                              URL is the base URL for the vedsdk endpoint of the Venafi TPP instance,
+                                              for example: "https://tpp.example.com/vedsdk".
+                                            type: string
+                                        required:
+                                          - credentialsRef
+                                          - url
+                                        type: object
+                                      zone:
+                                        description: |-
+                                          Zone is the Venafi Policy Zone to use for this issuer.
+                                          All requests made to the Venafi platform will be restricted by the named
+                                          zone policy.
+                                          This field is required.
+                                        type: string
+                                    required:
+                                      - zone
+                                    type: object
+                                type: object
+                            required:
+                              - name
+                              - spec
+                            type: object
+                          type: array
+                        issuers:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                              spec:
+                                description: |-
+                                  IssuerSpec is the specification of an Issuer. This includes any
+                                  configuration required for the issuer.
+                                properties:
+                                  acme:
+                                    description: |-
+                                      ACME configures this issuer to communicate with a RFC8555 (ACME) server
+                                      to obtain signed x509 certificates.
+                                    properties:
+                                      caBundle:
+                                        description: |-
+                                          Base64-encoded bundle of PEM CAs which can be used to validate the certificate
+                                          chain presented by the ACME server.
+                                          Mutually exclusive with SkipTLSVerify; prefer using CABundle to prevent various
+                                          kinds of security vulnerabilities.
+                                          If CABundle and SkipTLSVerify are unset, the system certificate bundle inside
+                                          the container is used to validate the TLS connection.
+                                        format: byte
+                                        type: string
+                                      disableAccountKeyGeneration:
+                                        description: |-
+                                          Enables or disables generating a new ACME account key.
+                                          If true, the Issuer resource will *not* request a new account but will expect
+                                          the account key to be supplied via an existing secret.
+                                          If false, the cert-manager system will generate a new ACME account key
+                                          for the Issuer.
+                                          Defaults to false.
+                                        type: boolean
+                                      email:
+                                        description: |-
+                                          Email is the email address to be associated with the ACME account.
+                                          This field is optional, but it is strongly recommended to be set.
+                                          It will be used to contact you in case of issues with your account or
+                                          certificates, including expiry notification emails.
+                                          This field may be updated after the account is initially registered.
+                                        type: string
+                                      enableDurationFeature:
+                                        description: |-
+                                          Enables requesting a Not After date on certificates that matches the
+                                          duration of the certificate. This is not supported by all ACME servers
+                                          like Let's Encrypt. If set to true when the ACME server does not support
+                                          it it will create an error on the Order.
+                                          Defaults to false.
+                                        type: boolean
+                                      externalAccountBinding:
+                                        description: |-
+                                          ExternalAccountBinding is a reference to a CA external account of the ACME
+                                          server.
+                                          If set, upon registration cert-manager will attempt to associate the given
+                                          external account credentials with the registered ACME account.
+                                        properties:
+                                          keyAlgorithm:
+                                            description: |-
+                                              Deprecated: keyAlgorithm field exists for historical compatibility
+                                              reasons and should not be used. The algorithm is now hardcoded to HS256
+                                              in golang/x/crypto/acme.
+                                            enum:
+                                              - HS256
+                                              - HS384
+                                              - HS512
+                                            type: string
+                                          keyID:
+                                            description: keyID is the ID of the CA key that the External Account is bound to.
+                                            type: string
+                                          keySecretRef:
+                                            description: |-
+                                              keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes
+                                              Secret which holds the symmetric MAC key of the External Account Binding.
+                                              The `key` is the index string that is paired with the key data in the
+                                              Secret and should not be confused with the key data itself, or indeed with
+                                              the External Account Binding keyID above.
+                                              The secret key stored in the Secret **must** be un-padded, base64 URL
+                                              encoded data.
+                                            properties:
+                                              key:
+                                                description: |-
+                                                  The key of the entry in the Secret resource's `data` field to be used.
+                                                  Some instances of this field may be defaulted, in others it may be
+                                                  required.
+                                                type: string
+                                              name:
+                                                description: |-
+                                                  Name of the resource being referred to.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                            required:
+                                              - name
+                                            type: object
+                                        required:
+                                          - keyID
+                                          - keySecretRef
+                                        type: object
+                                      preferredChain:
+                                        description: |-
+                                          PreferredChain is the chain to use if the ACME server outputs multiple.
+                                          PreferredChain is no guarantee that this one gets delivered by the ACME
+                                          endpoint.
+                                          For example, for Let's Encrypt's DST crosssign you would use:
+                                          "DST Root CA X3" or "ISRG Root X1" for the newer Let's Encrypt root CA.
+                                          This value picks the first certificate bundle in the ACME alternative
+                                          chains that has a certificate with this value as its issuer's CN
+                                        maxLength: 64
+                                        type: string
+                                      privateKeySecretRef:
+                                        description: |-
+                                          PrivateKey is the name of a Kubernetes Secret resource that will be used to
+                                          store the automatically generated ACME account private key.
+                                          Optionally, a `key` may be specified to select a specific entry within
+                                          the named Secret resource.
+                                          If `key` is not specified, a default of `tls.key` will be used.
+                                        properties:
+                                          key:
+                                            description: |-
+                                              The key of the entry in the Secret resource's `data` field to be used.
+                                              Some instances of this field may be defaulted, in others it may be
+                                              required.
+                                            type: string
+                                          name:
+                                            description: |-
+                                              Name of the resource being referred to.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                        required:
+                                          - name
+                                        type: object
+                                      server:
+                                        description: |-
+                                          Server is the URL used to access the ACME server's 'directory' endpoint.
+                                          For example, for Let's Encrypt's staging endpoint, you would use:
+                                          "https://acme-staging-v02.api.letsencrypt.org/directory".
+                                          Only ACME v2 endpoints (i.e. RFC 8555) are supported.
+                                        type: string
+                                      skipTLSVerify:
+                                        description: |-
+                                          INSECURE: Enables or disables validation of the ACME server TLS certificate.
+                                          If true, requests to the ACME server will not have the TLS certificate chain
+                                          validated.
+                                          Mutually exclusive with CABundle; prefer using CABundle to prevent various
+                                          kinds of security vulnerabilities.
+                                          Only enable this option in development environments.
+                                          If CABundle and SkipTLSVerify are unset, the system certificate bundle inside
+                                          the container is used to validate the TLS connection.
+                                          Defaults to false.
+                                        type: boolean
+                                      solvers:
+                                        description: |-
+                                          Solvers is a list of challenge solvers that will be used to solve
+                                          ACME challenges for the matching domains.
+                                          Solver configurations must be provided in order to obtain certificates
+                                          from an ACME server.
+                                          For more information, see: https://cert-manager.io/docs/configuration/acme/
+                                        items:
+                                          description: |-
+                                            An ACMEChallengeSolver describes how to solve ACME challenges for the issuer it is part of.
+                                            A selector may be provided to use different solving strategies for different DNS names.
+                                            Only one of HTTP01 or DNS01 must be provided.
+                                          properties:
+                                            dns01:
+                                              description: |-
+                                                Configures cert-manager to attempt to complete authorizations by
+                                                performing the DNS01 challenge flow.
+                                              properties:
+                                                acmeDNS:
+                                                  description: |-
+                                                    Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage
+                                                    DNS01 challenge records.
+                                                  properties:
+                                                    accountSecretRef:
+                                                      description: |-
+                                                        A reference to a specific 'key' within a Secret resource.
+                                                        In some instances, `key` is a required field.
+                                                      properties:
+                                                        key:
+                                                          description: |-
+                                                            The key of the entry in the Secret resource's `data` field to be used.
+                                                            Some instances of this field may be defaulted, in others it may be
+                                                            required.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the resource being referred to.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                      type: object
+                                                    host:
+                                                      type: string
+                                                  required:
+                                                    - accountSecretRef
+                                                    - host
+                                                  type: object
+                                                akamai:
+                                                  description: Use the Akamai DNS zone management API to manage DNS01 challenge records.
+                                                  properties:
+                                                    accessTokenSecretRef:
+                                                      description: |-
+                                                        A reference to a specific 'key' within a Secret resource.
+                                                        In some instances, `key` is a required field.
+                                                      properties:
+                                                        key:
+                                                          description: |-
+                                                            The key of the entry in the Secret resource's `data` field to be used.
+                                                            Some instances of this field may be defaulted, in others it may be
+                                                            required.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the resource being referred to.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                      type: object
+                                                    clientSecretSecretRef:
+                                                      description: |-
+                                                        A reference to a specific 'key' within a Secret resource.
+                                                        In some instances, `key` is a required field.
+                                                      properties:
+                                                        key:
+                                                          description: |-
+                                                            The key of the entry in the Secret resource's `data` field to be used.
+                                                            Some instances of this field may be defaulted, in others it may be
+                                                            required.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the resource being referred to.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                      type: object
+                                                    clientTokenSecretRef:
+                                                      description: |-
+                                                        A reference to a specific 'key' within a Secret resource.
+                                                        In some instances, `key` is a required field.
+                                                      properties:
+                                                        key:
+                                                          description: |-
+                                                            The key of the entry in the Secret resource's `data` field to be used.
+                                                            Some instances of this field may be defaulted, in others it may be
+                                                            required.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the resource being referred to.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                      type: object
+                                                    serviceConsumerDomain:
+                                                      type: string
+                                                  required:
+                                                    - accessTokenSecretRef
+                                                    - clientSecretSecretRef
+                                                    - clientTokenSecretRef
+                                                    - serviceConsumerDomain
+                                                  type: object
+                                                azureDNS:
+                                                  description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
+                                                  properties:
+                                                    clientID:
+                                                      description: |-
+                                                        Auth: Azure Service Principal:
+                                                        The ClientID of the Azure Service Principal used to authenticate with Azure DNS.
+                                                        If set, ClientSecret and TenantID must also be set.
+                                                      type: string
+                                                    clientSecretSecretRef:
+                                                      description: |-
+                                                        Auth: Azure Service Principal:
+                                                        A reference to a Secret containing the password associated with the Service Principal.
+                                                        If set, ClientID and TenantID must also be set.
+                                                      properties:
+                                                        key:
+                                                          description: |-
+                                                            The key of the entry in the Secret resource's `data` field to be used.
+                                                            Some instances of this field may be defaulted, in others it may be
+                                                            required.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the resource being referred to.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                      type: object
+                                                    environment:
+                                                      description: name of the Azure environment (default AzurePublicCloud)
+                                                      enum:
+                                                        - AzurePublicCloud
+                                                        - AzureChinaCloud
+                                                        - AzureGermanCloud
+                                                        - AzureUSGovernmentCloud
+                                                      type: string
+                                                    hostedZoneName:
+                                                      description: name of the DNS zone that should be used
+                                                      type: string
+                                                    managedIdentity:
+                                                      description: |-
+                                                        Auth: Azure Workload Identity or Azure Managed Service Identity:
+                                                        Settings to enable Azure Workload Identity or Azure Managed Service Identity
+                                                        If set, ClientID, ClientSecret and TenantID must not be set.
+                                                      properties:
+                                                        clientID:
+                                                          description: client ID of the managed identity, can not be used at the same time as resourceID
+                                                          type: string
+                                                        resourceID:
+                                                          description: |-
+                                                            resource ID of the managed identity, can not be used at the same time as clientID
+                                                            Cannot be used for Azure Managed Service Identity
+                                                          type: string
+                                                      type: object
+                                                    resourceGroupName:
+                                                      description: resource group the DNS zone is located in
+                                                      type: string
+                                                    subscriptionID:
+                                                      description: ID of the Azure subscription
+                                                      type: string
+                                                    tenantID:
+                                                      description: |-
+                                                        Auth: Azure Service Principal:
+                                                        The TenantID of the Azure Service Principal used to authenticate with Azure DNS.
+                                                        If set, ClientID and ClientSecret must also be set.
+                                                      type: string
+                                                  required:
+                                                    - resourceGroupName
+                                                    - subscriptionID
+                                                  type: object
+                                                cloudDNS:
+                                                  description: Use the Google Cloud DNS API to manage DNS01 challenge records.
+                                                  properties:
+                                                    hostedZoneName:
+                                                      description: |-
+                                                        HostedZoneName is an optional field that tells cert-manager in which
+                                                        Cloud DNS zone the challenge record has to be created.
+                                                        If left empty cert-manager will automatically choose a zone.
+                                                      type: string
+                                                    project:
+                                                      type: string
+                                                    serviceAccountSecretRef:
+                                                      description: |-
+                                                        A reference to a specific 'key' within a Secret resource.
+                                                        In some instances, `key` is a required field.
+                                                      properties:
+                                                        key:
+                                                          description: |-
+                                                            The key of the entry in the Secret resource's `data` field to be used.
+                                                            Some instances of this field may be defaulted, in others it may be
+                                                            required.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the resource being referred to.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                      type: object
+                                                  required:
+                                                    - project
+                                                  type: object
+                                                cloudflare:
+                                                  description: Use the Cloudflare API to manage DNS01 challenge records.
+                                                  properties:
+                                                    apiKeySecretRef:
+                                                      description: |-
+                                                        API key to use to authenticate with Cloudflare.
+                                                        Note: using an API token to authenticate is now the recommended method
+                                                        as it allows greater control of permissions.
+                                                      properties:
+                                                        key:
+                                                          description: |-
+                                                            The key of the entry in the Secret resource's `data` field to be used.
+                                                            Some instances of this field may be defaulted, in others it may be
+                                                            required.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the resource being referred to.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                      type: object
+                                                    apiTokenSecretRef:
+                                                      description: API token used to authenticate with Cloudflare.
+                                                      properties:
+                                                        key:
+                                                          description: |-
+                                                            The key of the entry in the Secret resource's `data` field to be used.
+                                                            Some instances of this field may be defaulted, in others it may be
+                                                            required.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the resource being referred to.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                      type: object
+                                                    email:
+                                                      description: Email of the account, only required when using API key based authentication.
+                                                      type: string
+                                                  type: object
+                                                cnameStrategy:
+                                                  description: |-
+                                                    CNAMEStrategy configures how the DNS01 provider should handle CNAME
+                                                    records when found in DNS zones.
+                                                  enum:
+                                                    - None
+                                                    - Follow
+                                                  type: string
+                                                digitalocean:
+                                                  description: Use the DigitalOcean DNS API to manage DNS01 challenge records.
+                                                  properties:
+                                                    tokenSecretRef:
+                                                      description: |-
+                                                        A reference to a specific 'key' within a Secret resource.
+                                                        In some instances, `key` is a required field.
+                                                      properties:
+                                                        key:
+                                                          description: |-
+                                                            The key of the entry in the Secret resource's `data` field to be used.
+                                                            Some instances of this field may be defaulted, in others it may be
+                                                            required.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the resource being referred to.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                      type: object
+                                                  required:
+                                                    - tokenSecretRef
+                                                  type: object
+                                                rfc2136:
+                                                  description: |-
+                                                    Use RFC2136 ("Dynamic Updates in the Domain Name System") (https://datatracker.ietf.org/doc/rfc2136/)
+                                                    to manage DNS01 challenge records.
+                                                  properties:
+                                                    nameserver:
+                                                      description: |-
+                                                        The IP address or hostname of an authoritative DNS server supporting
+                                                        RFC2136 in the form host:port. If the host is an IPv6 address it must be
+                                                        enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                                        This field is required.
+                                                      type: string
+                                                    tsigAlgorithm:
+                                                      description: |-
+                                                        The TSIG Algorithm configured in the DNS supporting RFC2136. Used only
+                                                        when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined.
+                                                        Supported values are (case-insensitive): ``HMACMD5`` (default),
+                                                        ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.
+                                                      type: string
+                                                    tsigKeyName:
+                                                      description: |-
+                                                        The TSIG Key name configured in the DNS.
+                                                        If ``tsigSecretSecretRef`` is defined, this field is required.
+                                                      type: string
+                                                    tsigSecretSecretRef:
+                                                      description: |-
+                                                        The name of the secret containing the TSIG value.
+                                                        If ``tsigKeyName`` is defined, this field is required.
+                                                      properties:
+                                                        key:
+                                                          description: |-
+                                                            The key of the entry in the Secret resource's `data` field to be used.
+                                                            Some instances of this field may be defaulted, in others it may be
+                                                            required.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the resource being referred to.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                      type: object
+                                                  required:
+                                                    - nameserver
+                                                  type: object
+                                                route53:
+                                                  description: Use the AWS Route53 API to manage DNS01 challenge records.
+                                                  properties:
+                                                    accessKeyID:
+                                                      description: |-
+                                                        The AccessKeyID is used for authentication.
+                                                        Cannot be set when SecretAccessKeyID is set.
+                                                        If neither the Access Key nor Key ID are set, we fall-back to using env
+                                                        vars, shared credentials file or AWS Instance metadata,
+                                                        see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                                      type: string
+                                                    accessKeyIDSecretRef:
+                                                      description: |-
+                                                        The SecretAccessKey is used for authentication. If set, pull the AWS
+                                                        access key ID from a key within a Kubernetes Secret.
+                                                        Cannot be set when AccessKeyID is set.
+                                                        If neither the Access Key nor Key ID are set, we fall-back to using env
+                                                        vars, shared credentials file or AWS Instance metadata,
+                                                        see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                                      properties:
+                                                        key:
+                                                          description: |-
+                                                            The key of the entry in the Secret resource's `data` field to be used.
+                                                            Some instances of this field may be defaulted, in others it may be
+                                                            required.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the resource being referred to.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                      type: object
+                                                    hostedZoneID:
+                                                      description: If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.
+                                                      type: string
+                                                    region:
+                                                      description: Always set the region when using AccessKeyID and SecretAccessKey
+                                                      type: string
+                                                    role:
+                                                      description: |-
+                                                        Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey
+                                                        or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata
+                                                      type: string
+                                                    secretAccessKeySecretRef:
+                                                      description: |-
+                                                        The SecretAccessKey is used for authentication.
+                                                        If neither the Access Key nor Key ID are set, we fall-back to using env
+                                                        vars, shared credentials file or AWS Instance metadata,
+                                                        see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                                      properties:
+                                                        key:
+                                                          description: |-
+                                                            The key of the entry in the Secret resource's `data` field to be used.
+                                                            Some instances of this field may be defaulted, in others it may be
+                                                            required.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the resource being referred to.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                      type: object
+                                                  required:
+                                                    - region
+                                                  type: object
+                                                webhook:
+                                                  description: |-
+                                                    Configure an external webhook based DNS01 challenge solver to manage
+                                                    DNS01 challenge records.
+                                                  properties:
+                                                    config:
+                                                      description: |-
+                                                        Additional configuration that should be passed to the webhook apiserver
+                                                        when challenges are processed.
+                                                        This can contain arbitrary JSON data.
+                                                        Secret values should not be specified in this stanza.
+                                                        If secret values are needed (e.g. credentials for a DNS service), you
+                                                        should use a SecretKeySelector to reference a Secret resource.
+                                                        For details on the schema of this field, consult the webhook provider
+                                                        implementation's documentation.
+                                                      x-kubernetes-preserve-unknown-fields: true
+                                                    groupName:
+                                                      description: |-
+                                                        The API group name that should be used when POSTing ChallengePayload
+                                                        resources to the webhook apiserver.
+                                                        This should be the same as the GroupName specified in the webhook
+                                                        provider implementation.
+                                                      type: string
+                                                    solverName:
+                                                      description: |-
+                                                        The name of the solver to use, as defined in the webhook provider
+                                                        implementation.
+                                                        This will typically be the name of the provider, e.g. 'cloudflare'.
+                                                      type: string
+                                                  required:
+                                                    - groupName
+                                                    - solverName
+                                                  type: object
+                                              type: object
+                                            http01:
+                                              description: |-
+                                                Configures cert-manager to attempt to complete authorizations by
+                                                performing the HTTP01 challenge flow.
+                                                It is not possible to obtain certificates for wildcard domain names
+                                                (e.g. `*.example.com`) using the HTTP01 challenge mechanism.
+                                              properties:
+                                                gatewayHTTPRoute:
+                                                  description: |-
+                                                    The Gateway API is a sig-network community API that models service networking
+                                                    in Kubernetes (https://gateway-api.sigs.k8s.io/). The Gateway solver will
+                                                    create HTTPRoutes with the specified labels in the same namespace as the challenge.
+                                                    This solver is experimental, and fields / behaviour may change in the future.
+                                                  properties:
+                                                    labels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: |-
+                                                        Custom labels that will be applied to HTTPRoutes created by cert-manager
+                                                        while solving HTTP-01 challenges.
+                                                      type: object
+                                                    parentRefs:
+                                                      description: |-
+                                                        When solving an HTTP-01 challenge, cert-manager creates an HTTPRoute.
+                                                        cert-manager needs to know which parentRefs should be used when creating
+                                                        the HTTPRoute. Usually, the parentRef references a Gateway. See:
+                                                        https://gateway-api.sigs.k8s.io/api-types/httproute/#attaching-to-gateways
+                                                      items:
+                                                        description: |-
+                                                          ParentReference identifies an API object (usually a Gateway) that can be considered
+                                                          a parent of this resource (usually a route). There are two kinds of parent resources
+                                                          with "Core" support:
+                                                          
+                                                          
+                                                          * Gateway (Gateway conformance profile)
+                                                          * Service (Mesh conformance profile, experimental, ClusterIP Services only)
+                                                          
+                                                          
+                                                          This API may be extended in the future to support additional kinds of parent
+                                                          resources.
+                                                          
+                                                          
+                                                          The API object must be valid in the cluster; the Group and Kind must
+                                                          be registered in the cluster for this reference to be valid.
+                                                        properties:
+                                                          group:
+                                                            default: gateway.networking.k8s.io
+                                                            description: |-
+                                                              Group is the group of the referent.
+                                                              When unspecified, "gateway.networking.k8s.io" is inferred.
+                                                              To set the core API group (such as for a "Service" kind referent),
+                                                              Group must be explicitly set to "" (empty string).
+                                                              
+                                                              
+                                                              Support: Core
+                                                            maxLength: 253
+                                                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                                            type: string
+                                                          kind:
+                                                            default: Gateway
+                                                            description: |-
+                                                              Kind is kind of the referent.
+                                                              
+                                                              
+                                                              There are two kinds of parent resources with "Core" support:
+                                                              
+                                                              
+                                                              * Gateway (Gateway conformance profile)
+                                                              * Service (Mesh conformance profile, experimental, ClusterIP Services only)
+                                                              
+                                                              
+                                                              Support for other resources is Implementation-Specific.
+                                                            maxLength: 63
+                                                            minLength: 1
+                                                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                                            type: string
+                                                          name:
+                                                            description: |-
+                                                              Name is the name of the referent.
+                                                              
+                                                              
+                                                              Support: Core
+                                                            maxLength: 253
+                                                            minLength: 1
+                                                            type: string
+                                                          namespace:
+                                                            description: |-
+                                                              Namespace is the namespace of the referent. When unspecified, this refers
+                                                              to the local namespace of the Route.
+                                                              
+                                                              
+                                                              Note that there are specific rules for ParentRefs which cross namespace
+                                                              boundaries. Cross-namespace references are only valid if they are explicitly
+                                                              allowed by something in the namespace they are referring to. For example:
+                                                              Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                                                              generic way to enable any other kind of cross-namespace reference.
+                                                              
+                                                              
+                                                              <gateway:experimental:description>
+                                                              ParentRefs from a Route to a Service in the same namespace are "producer"
+                                                              routes, which apply default routing rules to inbound connections from
+                                                              any namespace to the Service.
+                                                              
+                                                              
+                                                              ParentRefs from a Route to a Service in a different namespace are
+                                                              "consumer" routes, and these routing rules are only applied to outbound
+                                                              connections originating from the same namespace as the Route, for which
+                                                              the intended destination of the connections are a Service targeted as a
+                                                              ParentRef of the Route.
+                                                              </gateway:experimental:description>
+                                                              
+                                                              
+                                                              Support: Core
+                                                            maxLength: 63
+                                                            minLength: 1
+                                                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                                            type: string
+                                                          port:
+                                                            description: |-
+                                                              Port is the network port this Route targets. It can be interpreted
+                                                              differently based on the type of parent resource.
+                                                              
+                                                              
+                                                              When the parent resource is a Gateway, this targets all listeners
+                                                              listening on the specified port that also support this kind of Route(and
+                                                              select this Route). It's not recommended to set `Port` unless the
+                                                              networking behaviors specified in a Route must apply to a specific port
+                                                              as opposed to a listener(s) whose port(s) may be changed. When both Port
+                                                              and SectionName are specified, the name and port of the selected listener
+                                                              must match both specified values.
+                                                              
+                                                              
+                                                              <gateway:experimental:description>
+                                                              When the parent resource is a Service, this targets a specific port in the
+                                                              Service spec. When both Port (experimental) and SectionName are specified,
+                                                              the name and port of the selected port must match both specified values.
+                                                              </gateway:experimental:description>
+                                                              
+                                                              
+                                                              Implementations MAY choose to support other parent resources.
+                                                              Implementations supporting other types of parent resources MUST clearly
+                                                              document how/if Port is interpreted.
+                                                              
+                                                              
+                                                              For the purpose of status, an attachment is considered successful as
+                                                              long as the parent resource accepts it partially. For example, Gateway
+                                                              listeners can restrict which Routes can attach to them by Route kind,
+                                                              namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                                                              from the referencing Route, the Route MUST be considered successfully
+                                                              attached. If no Gateway listeners accept attachment from this Route,
+                                                              the Route MUST be considered detached from the Gateway.
+                                                              
+                                                              
+                                                              Support: Extended
+                                                              
+                                                              
+                                                              <gateway:experimental>
+                                                            format: int32
+                                                            maximum: 65535
+                                                            minimum: 1
+                                                            type: integer
+                                                          sectionName:
+                                                            description: |-
+                                                              SectionName is the name of a section within the target resource. In the
+                                                              following resources, SectionName is interpreted as the following:
+                                                              
+                                                              
+                                                              * Gateway: Listener Name. When both Port (experimental) and SectionName
+                                                              are specified, the name and port of the selected listener must match
+                                                              both specified values.
+                                                              * Service: Port Name. When both Port (experimental) and SectionName
+                                                              are specified, the name and port of the selected listener must match
+                                                              both specified values. Note that attaching Routes to Services as Parents
+                                                              is part of experimental Mesh support and is not supported for any other
+                                                              purpose.
+                                                              
+                                                              
+                                                              Implementations MAY choose to support attaching Routes to other resources.
+                                                              If that is the case, they MUST clearly document how SectionName is
+                                                              interpreted.
+                                                              
+                                                              
+                                                              When unspecified (empty string), this will reference the entire resource.
+                                                              For the purpose of status, an attachment is considered successful if at
+                                                              least one section in the parent resource accepts it. For example, Gateway
+                                                              listeners can restrict which Routes can attach to them by Route kind,
+                                                              namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                                                              the referencing Route, the Route MUST be considered successfully
+                                                              attached. If no Gateway listeners accept attachment from this Route, the
+                                                              Route MUST be considered detached from the Gateway.
+                                                              
+                                                              
+                                                              Support: Core
+                                                            maxLength: 253
+                                                            minLength: 1
+                                                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                                            type: string
+                                                        required:
+                                                          - name
+                                                        type: object
+                                                      type: array
+                                                    serviceType:
+                                                      description: |-
+                                                        Optional service type for Kubernetes solver service. Supported values
+                                                        are NodePort or ClusterIP. If unset, defaults to NodePort.
+                                                      type: string
+                                                  type: object
+                                                ingress:
+                                                  description: |-
+                                                    The ingress based HTTP01 challenge solver will solve challenges by
+                                                    creating or modifying Ingress resources in order to route requests for
+                                                    '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are
+                                                    provisioned by cert-manager for each Challenge to be completed.
+                                                  properties:
+                                                    class:
+                                                      description: |-
+                                                        This field configures the annotation `kubernetes.io/ingress.class` when
+                                                        creating Ingress resources to solve ACME challenges that use this
+                                                        challenge solver. Only one of `class`, `name` or `ingressClassName` may
+                                                        be specified.
+                                                      type: string
+                                                    ingressClassName:
+                                                      description: |-
+                                                        This field configures the field `ingressClassName` on the created Ingress
+                                                        resources used to solve ACME challenges that use this challenge solver.
+                                                        This is the recommended way of configuring the ingress class. Only one of
+                                                        `class`, `name` or `ingressClassName` may be specified.
+                                                      type: string
+                                                    ingressTemplate:
+                                                      description: |-
+                                                        Optional ingress template used to configure the ACME challenge solver
+                                                        ingress used for HTTP01 challenges.
+                                                      properties:
+                                                        metadata:
+                                                          description: |-
+                                                            ObjectMeta overrides for the ingress used to solve HTTP01 challenges.
+                                                            Only the 'labels' and 'annotations' fields may be set.
+                                                            If labels or annotations overlap with in-built values, the values here
+                                                            will override the in-built values.
+                                                          properties:
+                                                            annotations:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: Annotations that should be added to the created ACME HTTP01 solver ingress.
+                                                              type: object
+                                                            labels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: Labels that should be added to the created ACME HTTP01 solver ingress.
+                                                              type: object
+                                                          type: object
+                                                      type: object
+                                                    name:
+                                                      description: |-
+                                                        The name of the ingress resource that should have ACME challenge solving
+                                                        routes inserted into it in order to solve HTTP01 challenges.
+                                                        This is typically used in conjunction with ingress controllers like
+                                                        ingress-gce, which maintains a 1:1 mapping between external IPs and
+                                                        ingress resources. Only one of `class`, `name` or `ingressClassName` may
+                                                        be specified.
+                                                      type: string
+                                                    podTemplate:
+                                                      description: |-
+                                                        Optional pod template used to configure the ACME challenge solver pods
+                                                        used for HTTP01 challenges.
+                                                      properties:
+                                                        metadata:
+                                                          description: |-
+                                                            ObjectMeta overrides for the pod used to solve HTTP01 challenges.
+                                                            Only the 'labels' and 'annotations' fields may be set.
+                                                            If labels or annotations overlap with in-built values, the values here
+                                                            will override the in-built values.
+                                                          properties:
+                                                            annotations:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: Annotations that should be added to the create ACME HTTP01 solver pods.
+                                                              type: object
+                                                            labels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: Labels that should be added to the created ACME HTTP01 solver pods.
+                                                              type: object
+                                                          type: object
+                                                        spec:
+                                                          description: |-
+                                                            PodSpec defines overrides for the HTTP01 challenge solver pod.
+                                                            Check ACMEChallengeSolverHTTP01IngressPodSpec to find out currently supported fields.
+                                                            All other fields will be ignored.
+                                                          properties:
+                                                            affinity:
+                                                              description: If specified, the pod's scheduling constraints
+                                                              properties:
+                                                                nodeAffinity:
+                                                                  description: Describes node affinity scheduling rules for the pod.
+                                                                  properties:
+                                                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                                                      description: |-
+                                                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                                                        the affinity expressions specified by this field, but it may choose
+                                                                        a node that violates one or more of the expressions. The node that is
+                                                                        most preferred is the one with the greatest sum of weights, i.e.
+                                                                        for each node that meets all of the scheduling requirements (resource
+                                                                        request, requiredDuringScheduling affinity expressions, etc.),
+                                                                        compute a sum by iterating through the elements of this field and adding
+                                                                        "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                                                        node(s) with the highest sum are the most preferred.
+                                                                      items:
+                                                                        description: |-
+                                                                          An empty preferred scheduling term matches all objects with implicit weight 0
+                                                                          (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                                        properties:
+                                                                          preference:
+                                                                            description: A node selector term, associated with the corresponding weight.
+                                                                            properties:
+                                                                              matchExpressions:
+                                                                                description: A list of node selector requirements by node's labels.
+                                                                                items:
+                                                                                  description: |-
+                                                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                                                    that relates the key and values.
+                                                                                  properties:
+                                                                                    key:
+                                                                                      description: The label key that the selector applies to.
+                                                                                      type: string
+                                                                                    operator:
+                                                                                      description: |-
+                                                                                        Represents a key's relationship to a set of values.
+                                                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                                      type: string
+                                                                                    values:
+                                                                                      description: |-
+                                                                                        An array of string values. If the operator is In or NotIn,
+                                                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                                                        array must have a single element, which will be interpreted as an integer.
+                                                                                        This array is replaced during a strategic merge patch.
+                                                                                      items:
+                                                                                        type: string
+                                                                                      type: array
+                                                                                  required:
+                                                                                    - key
+                                                                                    - operator
+                                                                                  type: object
+                                                                                type: array
+                                                                              matchFields:
+                                                                                description: A list of node selector requirements by node's fields.
+                                                                                items:
+                                                                                  description: |-
+                                                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                                                    that relates the key and values.
+                                                                                  properties:
+                                                                                    key:
+                                                                                      description: The label key that the selector applies to.
+                                                                                      type: string
+                                                                                    operator:
+                                                                                      description: |-
+                                                                                        Represents a key's relationship to a set of values.
+                                                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                                      type: string
+                                                                                    values:
+                                                                                      description: |-
+                                                                                        An array of string values. If the operator is In or NotIn,
+                                                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                                                        array must have a single element, which will be interpreted as an integer.
+                                                                                        This array is replaced during a strategic merge patch.
+                                                                                      items:
+                                                                                        type: string
+                                                                                      type: array
+                                                                                  required:
+                                                                                    - key
+                                                                                    - operator
+                                                                                  type: object
+                                                                                type: array
+                                                                            type: object
+                                                                            x-kubernetes-map-type: atomic
+                                                                          weight:
+                                                                            description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                                            format: int32
+                                                                            type: integer
+                                                                        required:
+                                                                          - preference
+                                                                          - weight
+                                                                        type: object
+                                                                      type: array
+                                                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                                                      description: |-
+                                                                        If the affinity requirements specified by this field are not met at
+                                                                        scheduling time, the pod will not be scheduled onto the node.
+                                                                        If the affinity requirements specified by this field cease to be met
+                                                                        at some point during pod execution (e.g. due to an update), the system
+                                                                        may or may not try to eventually evict the pod from its node.
+                                                                      properties:
+                                                                        nodeSelectorTerms:
+                                                                          description: Required. A list of node selector terms. The terms are ORed.
+                                                                          items:
+                                                                            description: |-
+                                                                              A null or empty node selector term matches no objects. The requirements of
+                                                                              them are ANDed.
+                                                                              The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                                            properties:
+                                                                              matchExpressions:
+                                                                                description: A list of node selector requirements by node's labels.
+                                                                                items:
+                                                                                  description: |-
+                                                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                                                    that relates the key and values.
+                                                                                  properties:
+                                                                                    key:
+                                                                                      description: The label key that the selector applies to.
+                                                                                      type: string
+                                                                                    operator:
+                                                                                      description: |-
+                                                                                        Represents a key's relationship to a set of values.
+                                                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                                      type: string
+                                                                                    values:
+                                                                                      description: |-
+                                                                                        An array of string values. If the operator is In or NotIn,
+                                                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                                                        array must have a single element, which will be interpreted as an integer.
+                                                                                        This array is replaced during a strategic merge patch.
+                                                                                      items:
+                                                                                        type: string
+                                                                                      type: array
+                                                                                  required:
+                                                                                    - key
+                                                                                    - operator
+                                                                                  type: object
+                                                                                type: array
+                                                                              matchFields:
+                                                                                description: A list of node selector requirements by node's fields.
+                                                                                items:
+                                                                                  description: |-
+                                                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                                                    that relates the key and values.
+                                                                                  properties:
+                                                                                    key:
+                                                                                      description: The label key that the selector applies to.
+                                                                                      type: string
+                                                                                    operator:
+                                                                                      description: |-
+                                                                                        Represents a key's relationship to a set of values.
+                                                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                                      type: string
+                                                                                    values:
+                                                                                      description: |-
+                                                                                        An array of string values. If the operator is In or NotIn,
+                                                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                                                        array must have a single element, which will be interpreted as an integer.
+                                                                                        This array is replaced during a strategic merge patch.
+                                                                                      items:
+                                                                                        type: string
+                                                                                      type: array
+                                                                                  required:
+                                                                                    - key
+                                                                                    - operator
+                                                                                  type: object
+                                                                                type: array
+                                                                            type: object
+                                                                            x-kubernetes-map-type: atomic
+                                                                          type: array
+                                                                      required:
+                                                                        - nodeSelectorTerms
+                                                                      type: object
+                                                                      x-kubernetes-map-type: atomic
+                                                                  type: object
+                                                                podAffinity:
+                                                                  description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                                                  properties:
+                                                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                                                      description: |-
+                                                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                                                        the affinity expressions specified by this field, but it may choose
+                                                                        a node that violates one or more of the expressions. The node that is
+                                                                        most preferred is the one with the greatest sum of weights, i.e.
+                                                                        for each node that meets all of the scheduling requirements (resource
+                                                                        request, requiredDuringScheduling affinity expressions, etc.),
+                                                                        compute a sum by iterating through the elements of this field and adding
+                                                                        "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                                        node(s) with the highest sum are the most preferred.
+                                                                      items:
+                                                                        description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                                        properties:
+                                                                          podAffinityTerm:
+                                                                            description: Required. A pod affinity term, associated with the corresponding weight.
+                                                                            properties:
+                                                                              labelSelector:
+                                                                                description: |-
+                                                                                  A label query over a set of resources, in this case pods.
+                                                                                  If it's null, this PodAffinityTerm matches with no Pods.
+                                                                                properties:
+                                                                                  matchExpressions:
+                                                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                    items:
+                                                                                      description: |-
+                                                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                        relates the key and values.
+                                                                                      properties:
+                                                                                        key:
+                                                                                          description: key is the label key that the selector applies to.
+                                                                                          type: string
+                                                                                        operator:
+                                                                                          description: |-
+                                                                                            operator represents a key's relationship to a set of values.
+                                                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                          type: string
+                                                                                        values:
+                                                                                          description: |-
+                                                                                            values is an array of string values. If the operator is In or NotIn,
+                                                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                            the values array must be empty. This array is replaced during a strategic
+                                                                                            merge patch.
+                                                                                          items:
+                                                                                            type: string
+                                                                                          type: array
+                                                                                      required:
+                                                                                        - key
+                                                                                        - operator
+                                                                                      type: object
+                                                                                    type: array
+                                                                                  matchLabels:
+                                                                                    additionalProperties:
+                                                                                      type: string
+                                                                                    description: |-
+                                                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                    type: object
+                                                                                type: object
+                                                                                x-kubernetes-map-type: atomic
+                                                                              matchLabelKeys:
+                                                                                description: |-
+                                                                                  MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                                  be taken into consideration. The keys are used to lookup values from the
+                                                                                  incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                                                                  to select the group of existing pods which pods will be taken into consideration
+                                                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                                  pod labels will be ignored. The default value is empty.
+                                                                                  The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                                                                  Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                                items:
+                                                                                  type: string
+                                                                                type: array
+                                                                                x-kubernetes-list-type: atomic
+                                                                              mismatchLabelKeys:
+                                                                                description: |-
+                                                                                  MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                                  be taken into consideration. The keys are used to lookup values from the
+                                                                                  incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                                                                  to select the group of existing pods which pods will be taken into consideration
+                                                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                                  pod labels will be ignored. The default value is empty.
+                                                                                  The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                                                                  Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                                items:
+                                                                                  type: string
+                                                                                type: array
+                                                                                x-kubernetes-list-type: atomic
+                                                                              namespaceSelector:
+                                                                                description: |-
+                                                                                  A label query over the set of namespaces that the term applies to.
+                                                                                  The term is applied to the union of the namespaces selected by this field
+                                                                                  and the ones listed in the namespaces field.
+                                                                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                                                                  An empty selector ({}) matches all namespaces.
+                                                                                properties:
+                                                                                  matchExpressions:
+                                                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                    items:
+                                                                                      description: |-
+                                                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                        relates the key and values.
+                                                                                      properties:
+                                                                                        key:
+                                                                                          description: key is the label key that the selector applies to.
+                                                                                          type: string
+                                                                                        operator:
+                                                                                          description: |-
+                                                                                            operator represents a key's relationship to a set of values.
+                                                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                          type: string
+                                                                                        values:
+                                                                                          description: |-
+                                                                                            values is an array of string values. If the operator is In or NotIn,
+                                                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                            the values array must be empty. This array is replaced during a strategic
+                                                                                            merge patch.
+                                                                                          items:
+                                                                                            type: string
+                                                                                          type: array
+                                                                                      required:
+                                                                                        - key
+                                                                                        - operator
+                                                                                      type: object
+                                                                                    type: array
+                                                                                  matchLabels:
+                                                                                    additionalProperties:
+                                                                                      type: string
+                                                                                    description: |-
+                                                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                    type: object
+                                                                                type: object
+                                                                                x-kubernetes-map-type: atomic
+                                                                              namespaces:
+                                                                                description: |-
+                                                                                  namespaces specifies a static list of namespace names that the term applies to.
+                                                                                  The term is applied to the union of the namespaces listed in this field
+                                                                                  and the ones selected by namespaceSelector.
+                                                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                                                items:
+                                                                                  type: string
+                                                                                type: array
+                                                                              topologyKey:
+                                                                                description: |-
+                                                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                                  selected pods is running.
+                                                                                  Empty topologyKey is not allowed.
+                                                                                type: string
+                                                                            required:
+                                                                              - topologyKey
+                                                                            type: object
+                                                                          weight:
+                                                                            description: |-
+                                                                              weight associated with matching the corresponding podAffinityTerm,
+                                                                              in the range 1-100.
+                                                                            format: int32
+                                                                            type: integer
+                                                                        required:
+                                                                          - podAffinityTerm
+                                                                          - weight
+                                                                        type: object
+                                                                      type: array
+                                                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                                                      description: |-
+                                                                        If the affinity requirements specified by this field are not met at
+                                                                        scheduling time, the pod will not be scheduled onto the node.
+                                                                        If the affinity requirements specified by this field cease to be met
+                                                                        at some point during pod execution (e.g. due to a pod label update), the
+                                                                        system may or may not try to eventually evict the pod from its node.
+                                                                        When there are multiple elements, the lists of nodes corresponding to each
+                                                                        podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                                      items:
+                                                                        description: |-
+                                                                          Defines a set of pods (namely those matching the labelSelector
+                                                                          relative to the given namespace(s)) that this pod should be
+                                                                          co-located (affinity) or not co-located (anti-affinity) with,
+                                                                          where co-located is defined as running on a node whose value of
+                                                                          the label with key <topologyKey> matches that of any node on which
+                                                                          a pod of the set of pods is running
+                                                                        properties:
+                                                                          labelSelector:
+                                                                            description: |-
+                                                                              A label query over a set of resources, in this case pods.
+                                                                              If it's null, this PodAffinityTerm matches with no Pods.
+                                                                            properties:
+                                                                              matchExpressions:
+                                                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                items:
+                                                                                  description: |-
+                                                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                    relates the key and values.
+                                                                                  properties:
+                                                                                    key:
+                                                                                      description: key is the label key that the selector applies to.
+                                                                                      type: string
+                                                                                    operator:
+                                                                                      description: |-
+                                                                                        operator represents a key's relationship to a set of values.
+                                                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                      type: string
+                                                                                    values:
+                                                                                      description: |-
+                                                                                        values is an array of string values. If the operator is In or NotIn,
+                                                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                        the values array must be empty. This array is replaced during a strategic
+                                                                                        merge patch.
+                                                                                      items:
+                                                                                        type: string
+                                                                                      type: array
+                                                                                  required:
+                                                                                    - key
+                                                                                    - operator
+                                                                                  type: object
+                                                                                type: array
+                                                                              matchLabels:
+                                                                                additionalProperties:
+                                                                                  type: string
+                                                                                description: |-
+                                                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                type: object
+                                                                            type: object
+                                                                            x-kubernetes-map-type: atomic
+                                                                          matchLabelKeys:
+                                                                            description: |-
+                                                                              MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                              be taken into consideration. The keys are used to lookup values from the
+                                                                              incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                                                              to select the group of existing pods which pods will be taken into consideration
+                                                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                              pod labels will be ignored. The default value is empty.
+                                                                              The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                                                              Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                                              This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                            items:
+                                                                              type: string
+                                                                            type: array
+                                                                            x-kubernetes-list-type: atomic
+                                                                          mismatchLabelKeys:
+                                                                            description: |-
+                                                                              MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                              be taken into consideration. The keys are used to lookup values from the
+                                                                              incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                                                              to select the group of existing pods which pods will be taken into consideration
+                                                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                              pod labels will be ignored. The default value is empty.
+                                                                              The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                                                              Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                                              This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                            items:
+                                                                              type: string
+                                                                            type: array
+                                                                            x-kubernetes-list-type: atomic
+                                                                          namespaceSelector:
+                                                                            description: |-
+                                                                              A label query over the set of namespaces that the term applies to.
+                                                                              The term is applied to the union of the namespaces selected by this field
+                                                                              and the ones listed in the namespaces field.
+                                                                              null selector and null or empty namespaces list means "this pod's namespace".
+                                                                              An empty selector ({}) matches all namespaces.
+                                                                            properties:
+                                                                              matchExpressions:
+                                                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                items:
+                                                                                  description: |-
+                                                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                    relates the key and values.
+                                                                                  properties:
+                                                                                    key:
+                                                                                      description: key is the label key that the selector applies to.
+                                                                                      type: string
+                                                                                    operator:
+                                                                                      description: |-
+                                                                                        operator represents a key's relationship to a set of values.
+                                                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                      type: string
+                                                                                    values:
+                                                                                      description: |-
+                                                                                        values is an array of string values. If the operator is In or NotIn,
+                                                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                        the values array must be empty. This array is replaced during a strategic
+                                                                                        merge patch.
+                                                                                      items:
+                                                                                        type: string
+                                                                                      type: array
+                                                                                  required:
+                                                                                    - key
+                                                                                    - operator
+                                                                                  type: object
+                                                                                type: array
+                                                                              matchLabels:
+                                                                                additionalProperties:
+                                                                                  type: string
+                                                                                description: |-
+                                                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                type: object
+                                                                            type: object
+                                                                            x-kubernetes-map-type: atomic
+                                                                          namespaces:
+                                                                            description: |-
+                                                                              namespaces specifies a static list of namespace names that the term applies to.
+                                                                              The term is applied to the union of the namespaces listed in this field
+                                                                              and the ones selected by namespaceSelector.
+                                                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                                            items:
+                                                                              type: string
+                                                                            type: array
+                                                                          topologyKey:
+                                                                            description: |-
+                                                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                              whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                              selected pods is running.
+                                                                              Empty topologyKey is not allowed.
+                                                                            type: string
+                                                                        required:
+                                                                          - topologyKey
+                                                                        type: object
+                                                                      type: array
+                                                                  type: object
+                                                                podAntiAffinity:
+                                                                  description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                                                  properties:
+                                                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                                                      description: |-
+                                                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                                                        the anti-affinity expressions specified by this field, but it may choose
+                                                                        a node that violates one or more of the expressions. The node that is
+                                                                        most preferred is the one with the greatest sum of weights, i.e.
+                                                                        for each node that meets all of the scheduling requirements (resource
+                                                                        request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                                                        compute a sum by iterating through the elements of this field and adding
+                                                                        "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                                        node(s) with the highest sum are the most preferred.
+                                                                      items:
+                                                                        description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                                        properties:
+                                                                          podAffinityTerm:
+                                                                            description: Required. A pod affinity term, associated with the corresponding weight.
+                                                                            properties:
+                                                                              labelSelector:
+                                                                                description: |-
+                                                                                  A label query over a set of resources, in this case pods.
+                                                                                  If it's null, this PodAffinityTerm matches with no Pods.
+                                                                                properties:
+                                                                                  matchExpressions:
+                                                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                    items:
+                                                                                      description: |-
+                                                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                        relates the key and values.
+                                                                                      properties:
+                                                                                        key:
+                                                                                          description: key is the label key that the selector applies to.
+                                                                                          type: string
+                                                                                        operator:
+                                                                                          description: |-
+                                                                                            operator represents a key's relationship to a set of values.
+                                                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                          type: string
+                                                                                        values:
+                                                                                          description: |-
+                                                                                            values is an array of string values. If the operator is In or NotIn,
+                                                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                            the values array must be empty. This array is replaced during a strategic
+                                                                                            merge patch.
+                                                                                          items:
+                                                                                            type: string
+                                                                                          type: array
+                                                                                      required:
+                                                                                        - key
+                                                                                        - operator
+                                                                                      type: object
+                                                                                    type: array
+                                                                                  matchLabels:
+                                                                                    additionalProperties:
+                                                                                      type: string
+                                                                                    description: |-
+                                                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                    type: object
+                                                                                type: object
+                                                                                x-kubernetes-map-type: atomic
+                                                                              matchLabelKeys:
+                                                                                description: |-
+                                                                                  MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                                  be taken into consideration. The keys are used to lookup values from the
+                                                                                  incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                                                                  to select the group of existing pods which pods will be taken into consideration
+                                                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                                  pod labels will be ignored. The default value is empty.
+                                                                                  The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                                                                  Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                                items:
+                                                                                  type: string
+                                                                                type: array
+                                                                                x-kubernetes-list-type: atomic
+                                                                              mismatchLabelKeys:
+                                                                                description: |-
+                                                                                  MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                                  be taken into consideration. The keys are used to lookup values from the
+                                                                                  incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                                                                  to select the group of existing pods which pods will be taken into consideration
+                                                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                                  pod labels will be ignored. The default value is empty.
+                                                                                  The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                                                                  Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                                items:
+                                                                                  type: string
+                                                                                type: array
+                                                                                x-kubernetes-list-type: atomic
+                                                                              namespaceSelector:
+                                                                                description: |-
+                                                                                  A label query over the set of namespaces that the term applies to.
+                                                                                  The term is applied to the union of the namespaces selected by this field
+                                                                                  and the ones listed in the namespaces field.
+                                                                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                                                                  An empty selector ({}) matches all namespaces.
+                                                                                properties:
+                                                                                  matchExpressions:
+                                                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                    items:
+                                                                                      description: |-
+                                                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                        relates the key and values.
+                                                                                      properties:
+                                                                                        key:
+                                                                                          description: key is the label key that the selector applies to.
+                                                                                          type: string
+                                                                                        operator:
+                                                                                          description: |-
+                                                                                            operator represents a key's relationship to a set of values.
+                                                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                          type: string
+                                                                                        values:
+                                                                                          description: |-
+                                                                                            values is an array of string values. If the operator is In or NotIn,
+                                                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                            the values array must be empty. This array is replaced during a strategic
+                                                                                            merge patch.
+                                                                                          items:
+                                                                                            type: string
+                                                                                          type: array
+                                                                                      required:
+                                                                                        - key
+                                                                                        - operator
+                                                                                      type: object
+                                                                                    type: array
+                                                                                  matchLabels:
+                                                                                    additionalProperties:
+                                                                                      type: string
+                                                                                    description: |-
+                                                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                    type: object
+                                                                                type: object
+                                                                                x-kubernetes-map-type: atomic
+                                                                              namespaces:
+                                                                                description: |-
+                                                                                  namespaces specifies a static list of namespace names that the term applies to.
+                                                                                  The term is applied to the union of the namespaces listed in this field
+                                                                                  and the ones selected by namespaceSelector.
+                                                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                                                items:
+                                                                                  type: string
+                                                                                type: array
+                                                                              topologyKey:
+                                                                                description: |-
+                                                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                                  selected pods is running.
+                                                                                  Empty topologyKey is not allowed.
+                                                                                type: string
+                                                                            required:
+                                                                              - topologyKey
+                                                                            type: object
+                                                                          weight:
+                                                                            description: |-
+                                                                              weight associated with matching the corresponding podAffinityTerm,
+                                                                              in the range 1-100.
+                                                                            format: int32
+                                                                            type: integer
+                                                                        required:
+                                                                          - podAffinityTerm
+                                                                          - weight
+                                                                        type: object
+                                                                      type: array
+                                                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                                                      description: |-
+                                                                        If the anti-affinity requirements specified by this field are not met at
+                                                                        scheduling time, the pod will not be scheduled onto the node.
+                                                                        If the anti-affinity requirements specified by this field cease to be met
+                                                                        at some point during pod execution (e.g. due to a pod label update), the
+                                                                        system may or may not try to eventually evict the pod from its node.
+                                                                        When there are multiple elements, the lists of nodes corresponding to each
+                                                                        podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                                      items:
+                                                                        description: |-
+                                                                          Defines a set of pods (namely those matching the labelSelector
+                                                                          relative to the given namespace(s)) that this pod should be
+                                                                          co-located (affinity) or not co-located (anti-affinity) with,
+                                                                          where co-located is defined as running on a node whose value of
+                                                                          the label with key <topologyKey> matches that of any node on which
+                                                                          a pod of the set of pods is running
+                                                                        properties:
+                                                                          labelSelector:
+                                                                            description: |-
+                                                                              A label query over a set of resources, in this case pods.
+                                                                              If it's null, this PodAffinityTerm matches with no Pods.
+                                                                            properties:
+                                                                              matchExpressions:
+                                                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                items:
+                                                                                  description: |-
+                                                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                    relates the key and values.
+                                                                                  properties:
+                                                                                    key:
+                                                                                      description: key is the label key that the selector applies to.
+                                                                                      type: string
+                                                                                    operator:
+                                                                                      description: |-
+                                                                                        operator represents a key's relationship to a set of values.
+                                                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                      type: string
+                                                                                    values:
+                                                                                      description: |-
+                                                                                        values is an array of string values. If the operator is In or NotIn,
+                                                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                        the values array must be empty. This array is replaced during a strategic
+                                                                                        merge patch.
+                                                                                      items:
+                                                                                        type: string
+                                                                                      type: array
+                                                                                  required:
+                                                                                    - key
+                                                                                    - operator
+                                                                                  type: object
+                                                                                type: array
+                                                                              matchLabels:
+                                                                                additionalProperties:
+                                                                                  type: string
+                                                                                description: |-
+                                                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                type: object
+                                                                            type: object
+                                                                            x-kubernetes-map-type: atomic
+                                                                          matchLabelKeys:
+                                                                            description: |-
+                                                                              MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                              be taken into consideration. The keys are used to lookup values from the
+                                                                              incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                                                              to select the group of existing pods which pods will be taken into consideration
+                                                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                              pod labels will be ignored. The default value is empty.
+                                                                              The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                                                              Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                                              This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                            items:
+                                                                              type: string
+                                                                            type: array
+                                                                            x-kubernetes-list-type: atomic
+                                                                          mismatchLabelKeys:
+                                                                            description: |-
+                                                                              MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                              be taken into consideration. The keys are used to lookup values from the
+                                                                              incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                                                              to select the group of existing pods which pods will be taken into consideration
+                                                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                              pod labels will be ignored. The default value is empty.
+                                                                              The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                                                              Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                                              This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                            items:
+                                                                              type: string
+                                                                            type: array
+                                                                            x-kubernetes-list-type: atomic
+                                                                          namespaceSelector:
+                                                                            description: |-
+                                                                              A label query over the set of namespaces that the term applies to.
+                                                                              The term is applied to the union of the namespaces selected by this field
+                                                                              and the ones listed in the namespaces field.
+                                                                              null selector and null or empty namespaces list means "this pod's namespace".
+                                                                              An empty selector ({}) matches all namespaces.
+                                                                            properties:
+                                                                              matchExpressions:
+                                                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                items:
+                                                                                  description: |-
+                                                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                    relates the key and values.
+                                                                                  properties:
+                                                                                    key:
+                                                                                      description: key is the label key that the selector applies to.
+                                                                                      type: string
+                                                                                    operator:
+                                                                                      description: |-
+                                                                                        operator represents a key's relationship to a set of values.
+                                                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                      type: string
+                                                                                    values:
+                                                                                      description: |-
+                                                                                        values is an array of string values. If the operator is In or NotIn,
+                                                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                        the values array must be empty. This array is replaced during a strategic
+                                                                                        merge patch.
+                                                                                      items:
+                                                                                        type: string
+                                                                                      type: array
+                                                                                  required:
+                                                                                    - key
+                                                                                    - operator
+                                                                                  type: object
+                                                                                type: array
+                                                                              matchLabels:
+                                                                                additionalProperties:
+                                                                                  type: string
+                                                                                description: |-
+                                                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                type: object
+                                                                            type: object
+                                                                            x-kubernetes-map-type: atomic
+                                                                          namespaces:
+                                                                            description: |-
+                                                                              namespaces specifies a static list of namespace names that the term applies to.
+                                                                              The term is applied to the union of the namespaces listed in this field
+                                                                              and the ones selected by namespaceSelector.
+                                                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                                            items:
+                                                                              type: string
+                                                                            type: array
+                                                                          topologyKey:
+                                                                            description: |-
+                                                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                              whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                              selected pods is running.
+                                                                              Empty topologyKey is not allowed.
+                                                                            type: string
+                                                                        required:
+                                                                          - topologyKey
+                                                                        type: object
+                                                                      type: array
+                                                                  type: object
+                                                              type: object
+                                                            imagePullSecrets:
+                                                              description: If specified, the pod's imagePullSecrets
+                                                              items:
+                                                                description: |-
+                                                                  LocalObjectReference contains enough information to let you locate the
+                                                                  referenced object inside the same namespace.
+                                                                properties:
+                                                                  name:
+                                                                    description: |-
+                                                                      Name of the referent.
+                                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                                      TODO: Add other useful fields. apiVersion, kind, uid?
+                                                                    type: string
+                                                                type: object
+                                                                x-kubernetes-map-type: atomic
+                                                              type: array
+                                                            nodeSelector:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: |-
+                                                                NodeSelector is a selector which must be true for the pod to fit on a node.
+                                                                Selector which must match a node's labels for the pod to be scheduled on that node.
+                                                                More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                                                              type: object
+                                                            priorityClassName:
+                                                              description: If specified, the pod's priorityClassName.
+                                                              type: string
+                                                            serviceAccountName:
+                                                              description: If specified, the pod's service account
+                                                              type: string
+                                                            tolerations:
+                                                              description: If specified, the pod's tolerations.
+                                                              items:
+                                                                description: |-
+                                                                  The pod this Toleration is attached to tolerates any taint that matches
+                                                                  the triple <key,value,effect> using the matching operator <operator>.
+                                                                properties:
+                                                                  effect:
+                                                                    description: |-
+                                                                      Effect indicates the taint effect to match. Empty means match all taint effects.
+                                                                      When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                                                    type: string
+                                                                  key:
+                                                                    description: |-
+                                                                      Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                                                      If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      Operator represents a key's relationship to the value.
+                                                                      Valid operators are Exists and Equal. Defaults to Equal.
+                                                                      Exists is equivalent to wildcard for value, so that a pod can
+                                                                      tolerate all taints of a particular category.
+                                                                    type: string
+                                                                  tolerationSeconds:
+                                                                    description: |-
+                                                                      TolerationSeconds represents the period of time the toleration (which must be
+                                                                      of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                                                      it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                                                      negative values will be treated as 0 (evict immediately) by the system.
+                                                                    format: int64
+                                                                    type: integer
+                                                                  value:
+                                                                    description: |-
+                                                                      Value is the taint value the toleration matches to.
+                                                                      If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                                                    type: string
+                                                                type: object
+                                                              type: array
+                                                          type: object
+                                                      type: object
+                                                    serviceType:
+                                                      description: |-
+                                                        Optional service type for Kubernetes solver service. Supported values
+                                                        are NodePort or ClusterIP. If unset, defaults to NodePort.
+                                                      type: string
+                                                  type: object
+                                              type: object
+                                            selector:
+                                              description: |-
+                                                Selector selects a set of DNSNames on the Certificate resource that
+                                                should be solved using this challenge solver.
+                                                If not specified, the solver will be treated as the 'default' solver
+                                                with the lowest priority, i.e. if any other solver has a more specific
+                                                match, it will be used instead.
+                                              properties:
+                                                dnsNames:
+                                                  description: |-
+                                                    List of DNSNames that this solver will be used to solve.
+                                                    If specified and a match is found, a dnsNames selector will take
+                                                    precedence over a dnsZones selector.
+                                                    If multiple solvers match with the same dnsNames value, the solver
+                                                    with the most matching labels in matchLabels will be selected.
+                                                    If neither has more matches, the solver defined earlier in the list
+                                                    will be selected.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                dnsZones:
+                                                  description: |-
+                                                    List of DNSZones that this solver will be used to solve.
+                                                    The most specific DNS zone match specified here will take precedence
+                                                    over other DNS zone matches, so a solver specifying sys.example.com
+                                                    will be selected over one specifying example.com for the domain
+                                                    www.sys.example.com.
+                                                    If multiple solvers match with the same dnsZones value, the solver
+                                                    with the most matching labels in matchLabels will be selected.
+                                                    If neither has more matches, the solver defined earlier in the list
+                                                    will be selected.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    A label selector that is used to refine the set of certificate's that
+                                                    this challenge solver will apply to.
+                                                  type: object
+                                              type: object
+                                          type: object
+                                        type: array
+                                    required:
+                                      - privateKeySecretRef
+                                      - server
+                                    type: object
+                                  ca:
+                                    description: |-
+                                      CA configures this issuer to sign certificates using a signing CA keypair
+                                      stored in a Secret resource.
+                                      This is used to build internal PKIs that are managed by cert-manager.
+                                    properties:
+                                      crlDistributionPoints:
+                                        description: |-
+                                          The CRL distribution points is an X.509 v3 certificate extension which identifies
+                                          the location of the CRL from which the revocation of this certificate can be checked.
+                                          If not set, certificates will be issued without distribution points set.
+                                        items:
+                                          type: string
+                                        type: array
+                                      issuingCertificateURLs:
+                                        description: |-
+                                          IssuingCertificateURLs is a list of URLs which this issuer should embed into certificates
+                                          it creates. See https://www.rfc-editor.org/rfc/rfc5280#section-4.2.2.1 for more details.
+                                          As an example, such a URL might be "http://ca.domain.com/ca.crt".
+                                        items:
+                                          type: string
+                                        type: array
+                                      ocspServers:
+                                        description: |-
+                                          The OCSP server list is an X.509 v3 extension that defines a list of
+                                          URLs of OCSP responders. The OCSP responders can be queried for the
+                                          revocation status of an issued certificate. If not set, the
+                                          certificate will be issued with no OCSP servers set. For example, an
+                                          OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                                        items:
+                                          type: string
+                                        type: array
+                                      secretName:
+                                        description: |-
+                                          SecretName is the name of the secret used to sign Certificates issued
+                                          by this Issuer.
+                                        type: string
+                                    required:
+                                      - secretName
+                                    type: object
+                                  selfSigned:
+                                    description: |-
+                                      SelfSigned configures this issuer to 'self sign' certificates using the
+                                      private key used to create the CertificateRequest object.
+                                    properties:
+                                      crlDistributionPoints:
+                                        description: |-
+                                          The CRL distribution points is an X.509 v3 certificate extension which identifies
+                                          the location of the CRL from which the revocation of this certificate can be checked.
+                                          If not set certificate will be issued without CDP. Values are strings.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  vault:
+                                    description: |-
+                                      Vault configures this issuer to sign certificates using a HashiCorp Vault
+                                      PKI backend.
+                                    properties:
+                                      auth:
+                                        description: Auth configures how cert-manager authenticates with the Vault server.
+                                        properties:
+                                          appRole:
+                                            description: |-
+                                              AppRole authenticates with Vault using the App Role auth mechanism,
+                                              with the role and secret stored in a Kubernetes Secret resource.
+                                            properties:
+                                              path:
+                                                description: |-
+                                                  Path where the App Role authentication backend is mounted in Vault, e.g:
+                                                  "approle"
+                                                type: string
+                                              roleId:
+                                                description: |-
+                                                  RoleID configured in the App Role authentication backend when setting
+                                                  up the authentication backend in Vault.
+                                                type: string
+                                              secretRef:
+                                                description: |-
+                                                  Reference to a key in a Secret that contains the App Role secret used
+                                                  to authenticate with Vault.
+                                                  The `key` field must be specified and denotes which entry within the Secret
+                                                  resource is used as the app role secret.
+                                                properties:
+                                                  key:
+                                                    description: |-
+                                                      The key of the entry in the Secret resource's `data` field to be used.
+                                                      Some instances of this field may be defaulted, in others it may be
+                                                      required.
+                                                    type: string
+                                                  name:
+                                                    description: |-
+                                                      Name of the resource being referred to.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                required:
+                                                  - name
+                                                type: object
+                                            required:
+                                              - path
+                                              - roleId
+                                              - secretRef
+                                            type: object
+                                          kubernetes:
+                                            description: |-
+                                              Kubernetes authenticates with Vault by passing the ServiceAccount
+                                              token stored in the named Secret resource to the Vault server.
+                                            properties:
+                                              mountPath:
+                                                description: |-
+                                                  The Vault mountPath here is the mount path to use when authenticating with
+                                                  Vault. For example, setting a value to `/v1/auth/foo`, will use the path
+                                                  `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the
+                                                  default value "/v1/auth/kubernetes" will be used.
+                                                type: string
+                                              role:
+                                                description: |-
+                                                  A required field containing the Vault Role to assume. A Role binds a
+                                                  Kubernetes ServiceAccount with a set of Vault policies.
+                                                type: string
+                                              secretRef:
+                                                description: |-
+                                                  The required Secret field containing a Kubernetes ServiceAccount JWT used
+                                                  for authenticating with Vault. Use of 'ambient credentials' is not
+                                                  supported.
+                                                properties:
+                                                  key:
+                                                    description: |-
+                                                      The key of the entry in the Secret resource's `data` field to be used.
+                                                      Some instances of this field may be defaulted, in others it may be
+                                                      required.
+                                                    type: string
+                                                  name:
+                                                    description: |-
+                                                      Name of the resource being referred to.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                required:
+                                                  - name
+                                                type: object
+                                              serviceAccountRef:
+                                                description: |-
+                                                  A reference to a service account that will be used to request a bound
+                                                  token (also known as "projected token"). Compared to using "secretRef",
+                                                  using this field means that you don't rely on statically bound tokens. To
+                                                  use this field, you must configure an RBAC rule to let cert-manager
+                                                  request a token.
+                                                properties:
+                                                  name:
+                                                    description: Name of the ServiceAccount used to request a token.
+                                                    type: string
+                                                required:
+                                                  - name
+                                                type: object
+                                            required:
+                                              - role
+                                            type: object
+                                          tokenSecretRef:
+                                            description: TokenSecretRef authenticates with Vault by presenting a token.
+                                            properties:
+                                              key:
+                                                description: |-
+                                                  The key of the entry in the Secret resource's `data` field to be used.
+                                                  Some instances of this field may be defaulted, in others it may be
+                                                  required.
+                                                type: string
+                                              name:
+                                                description: |-
+                                                  Name of the resource being referred to.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                            required:
+                                              - name
+                                            type: object
+                                        type: object
+                                      caBundle:
+                                        description: |-
+                                          Base64-encoded bundle of PEM CAs which will be used to validate the certificate
+                                          chain presented by Vault. Only used if using HTTPS to connect to Vault and
+                                          ignored for HTTP connections.
+                                          Mutually exclusive with CABundleSecretRef.
+                                          If neither CABundle nor CABundleSecretRef are defined, the certificate bundle in
+                                          the cert-manager controller container is used to validate the TLS connection.
+                                        format: byte
+                                        type: string
+                                      caBundleSecretRef:
+                                        description: |-
+                                          Reference to a Secret containing a bundle of PEM-encoded CAs to use when
+                                          verifying the certificate chain presented by Vault when using HTTPS.
+                                          Mutually exclusive with CABundle.
+                                          If neither CABundle nor CABundleSecretRef are defined, the certificate bundle in
+                                          the cert-manager controller container is used to validate the TLS connection.
+                                          If no key for the Secret is specified, cert-manager will default to 'ca.crt'.
+                                        properties:
+                                          key:
+                                            description: |-
+                                              The key of the entry in the Secret resource's `data` field to be used.
+                                              Some instances of this field may be defaulted, in others it may be
+                                              required.
+                                            type: string
+                                          name:
+                                            description: |-
+                                              Name of the resource being referred to.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                        required:
+                                          - name
+                                        type: object
+                                      namespace:
+                                        description: |-
+                                          Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1"
+                                          More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces
+                                        type: string
+                                      path:
+                                        description: |-
+                                          Path is the mount path of the Vault PKI backend's `sign` endpoint, e.g:
+                                          "my_pki_mount/sign/my-role-name".
+                                        type: string
+                                      server:
+                                        description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                                        type: string
+                                    required:
+                                      - auth
+                                      - path
+                                      - server
+                                    type: object
+                                  venafi:
+                                    description: |-
+                                      Venafi configures this issuer to sign certificates using a Venafi TPP
+                                      or Venafi Cloud policy zone.
+                                    properties:
+                                      cloud:
+                                        description: |-
+                                          Cloud specifies the Venafi cloud configuration settings.
+                                          Only one of TPP or Cloud may be specified.
+                                        properties:
+                                          apiTokenSecretRef:
+                                            description: APITokenSecretRef is a secret key selector for the Venafi Cloud API token.
+                                            properties:
+                                              key:
+                                                description: |-
+                                                  The key of the entry in the Secret resource's `data` field to be used.
+                                                  Some instances of this field may be defaulted, in others it may be
+                                                  required.
+                                                type: string
+                                              name:
+                                                description: |-
+                                                  Name of the resource being referred to.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                            required:
+                                              - name
+                                            type: object
+                                          url:
+                                            description: |-
+                                              URL is the base URL for Venafi Cloud.
+                                              Defaults to "https://api.venafi.cloud/v1".
+                                            type: string
+                                        required:
+                                          - apiTokenSecretRef
+                                        type: object
+                                      tpp:
+                                        description: |-
+                                          TPP specifies Trust Protection Platform configuration settings.
+                                          Only one of TPP or Cloud may be specified.
+                                        properties:
+                                          caBundle:
+                                            description: |-
+                                              Base64-encoded bundle of PEM CAs which will be used to validate the certificate
+                                              chain presented by the TPP server. Only used if using HTTPS; ignored for HTTP.
+                                              If undefined, the certificate bundle in the cert-manager controller container
+                                              is used to validate the chain.
+                                            format: byte
+                                            type: string
+                                          credentialsRef:
+                                            description: |-
+                                              CredentialsRef is a reference to a Secret containing the username and
+                                              password for the TPP server.
+                                              The secret must contain two keys, 'username' and 'password'.
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  Name of the resource being referred to.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                            required:
+                                              - name
+                                            type: object
+                                          url:
+                                            description: |-
+                                              URL is the base URL for the vedsdk endpoint of the Venafi TPP instance,
+                                              for example: "https://tpp.example.com/vedsdk".
+                                            type: string
+                                        required:
+                                          - credentialsRef
+                                          - url
+                                        type: object
+                                      zone:
+                                        description: |-
+                                          Zone is the Venafi Policy Zone to use for this issuer.
+                                          All requests made to the Venafi platform will be restricted by the named
+                                          zone policy.
+                                          This field is required.
+                                        type: string
+                                    required:
+                                      - zone
+                                    type: object
+                                type: object
+                            required:
+                              - name
+                              - namespace
+                              - spec
+                            type: object
+                          type: array
                       type: object
-                    type: array
-                type: object
-            type: object
-          status:
-            description: BlueprintStatus defines the observed state of Blueprint
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  type: object
+              type: object
+            status:
+              description: BlueprintStatus defines the observed state of Blueprint
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-    controller-gen.kubebuilder.io/version: v0.11.1
-  name: ingresses.boundless.mirantis.com
-spec:
-  conversion:
-    strategy: Webhook
-    webhook:
-      clientConfig:
-        service:
-          name: webhook-service
-          namespace: boundless-system
-          path: /convert
-      conversionReviewVersions:
-      - v1
-  group: boundless.mirantis.com
-  names:
-    kind: Ingress
-    listKind: IngressList
-    plural: ingresses
-    singular: ingress
-  scope: Namespaced
-  versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: Ingress is the Schema for the ingresses API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: IngressSpec defines the desired state of Ingress
-            properties:
-              config:
-                type: string
-              enabled:
-                description: Enabled is a flag to enable/disable the ingress
-                type: boolean
-              provider:
-                type: string
-            required:
-            - enabled
-            - provider
-            type: object
-          status:
-            description: IngressStatus defines the observed state of Ingress
-            properties:
-              ingressReady:
-                type: boolean
-            required:
-            - ingressReady
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
----
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-    controller-gen.kubebuilder.io/version: v0.11.1
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: installations.boundless.mirantis.com
 spec:
   conversion:
@@ -477,7 +5414,7 @@ spec:
           namespace: boundless-system
           path: /convert
       conversionReviewVersions:
-      - v1
+        - v1
   group: boundless.mirantis.com
   names:
     kind: Installation
@@ -486,82 +5423,110 @@ spec:
     singular: installation
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: Installation is the Schema for the installations API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: InstallationSpec defines the desired state of Installation
-            type: object
-          status:
-            description: InstallationStatus defines the observed state of Installation
-            properties:
-              conditions:
-                description: Conditions represents the latest observed set of conditions for the component. A component may be one or more of Ready, Progressing, Degraded or other customer types.
-                items:
-                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
-                  properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human readable message indicating details about the transition. This may be an empty string.
-                      maxLength: 32768
-                      type: string
-                    observedGeneration:
-                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
-                      format: int64
-                      minimum: 0
-                      type: integer
-                    reason:
-                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
-                      maxLength: 1024
-                      minLength: 1
-                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-                      type: string
-                    status:
-                      description: status of the condition, one of True, False, Unknown.
-                      enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                      type: string
-                    type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-                      maxLength: 316
-                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-                      type: string
-                  required:
-                  - lastTransitionTime
-                  - message
-                  - reason
-                  - status
-                  - type
-                  type: object
-                type: array
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Installation is the Schema for the installations API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: InstallationSpec defines the desired state of Installation
+              type: object
+            status:
+              description: InstallationStatus defines the observed state of Installation
+              properties:
+                conditions:
+                  description: |-
+                    Conditions represents the latest observed set of conditions for the component. A component may be one or more of
+                    Ready, Progressing, Degraded or other customer types.
+                  items:
+                    description: "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}"
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: |-
+                          type of condition in CamelCase or in foo.example.com/CamelCase.
+                          ---
+                          Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                          useful (see .node.status.conditions), the ability to deconflict is important.
+                          The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-    controller-gen.kubebuilder.io/version: v0.11.1
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: manifests.boundless.mirantis.com
 spec:
   conversion:
@@ -573,7 +5538,7 @@ spec:
           namespace: boundless-system
           path: /convert
       conversionReviewVersions:
-      - v1
+        - v1
   group: boundless.mirantis.com
   names:
     kind: Manifest
@@ -582,158 +5547,189 @@ spec:
     singular: manifest
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Whether the component is running and stable.
-      jsonPath: .status.type
-      name: Status
-      type: string
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: Manifest is the Schema for the manifests API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ManifestSpec defines the desired state of Manifest
-            properties:
-              checksum:
-                type: string
-              failurePolicy:
-                description: 'This flag tells the controller how to handle the manifest in case of a failure. Valid values are: - None (default) : No-op; No action is triggered on manifest failure - Retry : Manifest is retried in case of failure. For install, the manifest resources are deleted and re-installed. For update, the new version of the manifest is applied on top of existing resources.'
-                type: string
-              newChecksum:
-                type: string
-              objects:
-                items:
-                  description: ManifestObject consists of the fields required to update/delete an object
+    - additionalPrinterColumns:
+        - description: Whether the component is running and stable.
+          jsonPath: .status.type
+          name: Status
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Manifest is the Schema for the manifests API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ManifestSpec defines the desired state of Manifest
+              properties:
+                checksum:
+                  type: string
+                failurePolicy:
+                  description: "This flag tells the controller how to handle the manifest in case of a failure.\nValid values are:\n- None (default) : No-op; No action is triggered on manifest failure\n- Retry : Manifest is retried in case of failure. For install, the manifest resources are deleted and re-installed.\n\t\t\t For update, the new version of the manifest is applied on top of existing resources."
+                  type: string
+                newChecksum:
+                  type: string
+                objects:
+                  items:
+                    description: ManifestObject consists of the fields required to update/delete an object
+                    properties:
+                      group:
+                        type: string
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                      version:
+                        type: string
+                    required:
+                      - group
+                      - kind
+                      - name
+                      - namespace
+                      - version
+                    type: object
+                  type: array
+                timeout:
+                  description: |-
+                    Timeout for manifest operations as duration string (300s, 10m, 1h, etc)
+                    If manifest is not Available after timeout duration, it will be handled by specified FailurePolicy
+                  type: string
+                url:
+                  type: string
+                values:
                   properties:
-                    group:
-                      type: string
-                    kind:
-                      type: string
-                    name:
-                      type: string
-                    namespace:
-                      type: string
-                    version:
-                      type: string
-                  required:
-                  - group
-                  - kind
-                  - name
-                  - namespace
-                  - version
+                    images:
+                      description: |-
+                        Images is a list of (image name, new name, new tag or digest)
+                        for changing image names, tags or digests. This can also be achieved with a
+                        patch, but this operator is simpler to specify.
+                      items:
+                        description: Image contains an image name, a new name, a new tag or digest, which will replace the original name and tag.
+                        properties:
+                          digest:
+                            description: |-
+                              Digest is the value used to replace the original image tag.
+                              If digest is present NewTag value is ignored.
+                            type: string
+                          name:
+                            description: Name is a tag-less image name.
+                            type: string
+                          newName:
+                            description: NewName is the value used to replace the original name.
+                            type: string
+                          newTag:
+                            description: NewTag is the value used to replace the original tag.
+                            type: string
+                          tagSuffix:
+                            description: |-
+                              TagSuffix is the value used to suffix the original tag
+                              If Digest and NewTag is present an error is thrown
+                            type: string
+                        type: object
+                      type: array
+                    patches:
+                      description: |-
+                        Patches is a list of patches, where each one can be either a
+                        Strategic Merge Patch or a JSON patch.
+                        Each patch can be applied to multiple target objects.
+                      items:
+                        description: |-
+                          Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should
+                          be applied to. This is in coherence with https://github.com/kubernetes-sigs/kustomize/blob/api/v0.16.0/api/types/patch.go#L12
+                        properties:
+                          options:
+                            additionalProperties:
+                              type: boolean
+                            description: Options is a list of options for the patch
+                            type: object
+                          patch:
+                            description: |-
+                              Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
+                              an array of operation objects.
+                            type: string
+                          path:
+                            description: Path is a relative file path to the patch file.
+                            type: string
+                          target:
+                            description: Target points to the resources that the patch document should be applied to.
+                            properties:
+                              annotationSelector:
+                                description: |-
+                                  AnnotationSelector is a string that follows the label selection expression
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                  It matches with the resource annotations.
+                                type: string
+                              group:
+                                type: string
+                              kind:
+                                type: string
+                              labelSelector:
+                                description: |-
+                                  LabelSelector is a string that follows the label selection expression
+                                  https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api
+                                  It matches with the resource labels.
+                                type: string
+                              name:
+                                description: Name of the resource.
+                                type: string
+                              namespace:
+                                description: Namespace the resource belongs to, if it can belong to a namespace.
+                                type: string
+                              version:
+                                type: string
+                            type: object
+                        required:
+                          - patch
+                        type: object
+                      type: array
                   type: object
-                type: array
-              timeout:
-                description: Timeout for manifest operations as duration string (300s, 10m, 1h, etc) If manifest is not Available after timeout duration, it will be handled by specified FailurePolicy
-                type: string
-              url:
-                type: string
-              values:
-                properties:
-                  images:
-                    description: Images is a list of (image name, new name, new tag or digest) for changing image names, tags or digests. This can also be achieved with a patch, but this operator is simpler to specify.
-                    items:
-                      description: Image contains an image name, a new name, a new tag or digest, which will replace the original name and tag.
-                      properties:
-                        digest:
-                          description: Digest is the value used to replace the original image tag. If digest is present NewTag value is ignored.
-                          type: string
-                        name:
-                          description: Name is a tag-less image name.
-                          type: string
-                        newName:
-                          description: NewName is the value used to replace the original name.
-                          type: string
-                        newTag:
-                          description: NewTag is the value used to replace the original tag.
-                          type: string
-                        tagSuffix:
-                          description: TagSuffix is the value used to suffix the original tag If Digest and NewTag is present an error is thrown
-                          type: string
-                      type: object
-                    type: array
-                  patches:
-                    description: Patches is a list of patches, where each one can be either a Strategic Merge Patch or a JSON patch. Each patch can be applied to multiple target objects.
-                    items:
-                      description: Patch contains an inline StrategicMerge or JSON6902 patch, and the target the patch should be applied to. This is in coherence with https://github.com/kubernetes-sigs/kustomize/blob/api/v0.16.0/api/types/patch.go#L12
-                      properties:
-                        options:
-                          additionalProperties:
-                            type: boolean
-                          description: Options is a list of options for the patch
-                          type: object
-                        patch:
-                          description: Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with an array of operation objects.
-                          type: string
-                        path:
-                          description: Path is a relative file path to the patch file.
-                          type: string
-                        target:
-                          description: Target points to the resources that the patch document should be applied to.
-                          properties:
-                            annotationSelector:
-                              description: AnnotationSelector is a string that follows the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api It matches with the resource annotations.
-                              type: string
-                            group:
-                              type: string
-                            kind:
-                              type: string
-                            labelSelector:
-                              description: LabelSelector is a string that follows the label selection expression https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#api It matches with the resource labels.
-                              type: string
-                            name:
-                              description: Name of the resource.
-                              type: string
-                            namespace:
-                              description: Namespace the resource belongs to, if it can belong to a namespace.
-                              type: string
-                            version:
-                              type: string
-                          type: object
-                      required:
-                      - patch
-                      type: object
-                    type: array
-                type: object
-            required:
-            - checksum
-            - failurePolicy
-            - url
-            type: object
-          status:
-            description: ManifestStatus defines the observed state of Manifest
-            properties:
-              lastTransitionTime:
-                description: The timestamp representing the start time for the current status.
-                format: date-time
-                type: string
-              message:
-                description: Optionally, a detailed message providing additional context.
-                type: string
-              reason:
-                description: A brief reason explaining the condition.
-                type: string
-              type:
-                description: The type of condition. May be Available, Progressing, or Degraded.
-                type: string
-            required:
-            - lastTransitionTime
-            - type
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+              required:
+                - checksum
+                - failurePolicy
+                - url
+              type: object
+            status:
+              description: ManifestStatus defines the observed state of Manifest
+              properties:
+                lastTransitionTime:
+                  description: The timestamp representing the start time for the current status.
+                  format: date-time
+                  type: string
+                message:
+                  description: Optionally, a detailed message providing additional context.
+                  type: string
+                reason:
+                  description: A brief reason explaining the condition.
+                  type: string
+                type:
+                  description: The type of condition. May be Available, Progressing, or Degraded.
+                  type: string
+              required:
+                - lastTransitionTime
+                - type
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -761,197 +5757,196 @@ metadata:
   name: boundless-operator-leader-election-role
   namespace: boundless-system
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: boundless-operator-manager-role
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - daemonsets/status
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments/status
-  verbs:
-  - get
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - batch
-  resources:
-  - jobs/status
-  verbs:
-  - get
-- apiGroups:
-  - boundless.mirantis.com
-  resources:
-  - addons
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - boundless.mirantis.com
-  resources:
-  - addons/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - boundless.mirantis.com
-  resources:
-  - addons/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - boundless.mirantis.com
-  resources:
-  - blueprints
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - boundless.mirantis.com
-  resources:
-  - blueprints/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - boundless.mirantis.com
-  resources:
-  - blueprints/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - boundless.mirantis.com
-  resources:
-  - installations
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - boundless.mirantis.com
-  resources:
-  - installations/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - boundless.mirantis.com
-  resources:
-  - installations/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - boundless.mirantis.com
-  resources:
-  - manifests
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - boundless.mirantis.com
-  resources:
-  - manifests/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - boundless.mirantis.com
-  resources:
-  - manifests/status
-  verbs:
-  - get
-  - patch
-  - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets/status
+    verbs:
+      - get
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments/status
+    verbs:
+      - get
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs/status
+    verbs:
+      - get
+  - apiGroups:
+      - boundless.mirantis.com
+    resources:
+      - addons
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - boundless.mirantis.com
+    resources:
+      - addons/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - boundless.mirantis.com
+    resources:
+      - addons/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - boundless.mirantis.com
+    resources:
+      - blueprints
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - boundless.mirantis.com
+    resources:
+      - blueprints/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - boundless.mirantis.com
+    resources:
+      - blueprints/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - boundless.mirantis.com
+    resources:
+      - installations
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - boundless.mirantis.com
+    resources:
+      - installations/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - boundless.mirantis.com
+    resources:
+      - installations/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - boundless.mirantis.com
+    resources:
+      - manifests
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - boundless.mirantis.com
+    resources:
+      - manifests/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - boundless.mirantis.com
+    resources:
+      - manifests/status
+    verbs:
+      - get
+      - patch
+      - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -965,10 +5960,10 @@ metadata:
     app.kubernetes.io/part-of: boundless-operator
   name: boundless-operator-metrics-reader
 rules:
-- nonResourceURLs:
-  - /metrics
-  verbs:
-  - get
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -982,18 +5977,18 @@ metadata:
     app.kubernetes.io/part-of: boundless-operator
   name: boundless-operator-proxy-role
 rules:
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -1012,9 +6007,9 @@ roleRef:
   kind: Role
   name: boundless-operator-leader-election-role
 subjects:
-- kind: ServiceAccount
-  name: boundless-operator-controller-manager
-  namespace: boundless-system
+  - kind: ServiceAccount
+    name: boundless-operator-controller-manager
+    namespace: boundless-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1032,9 +6027,9 @@ roleRef:
   kind: ClusterRole
   name: cluster-admin
 subjects:
-- kind: ServiceAccount
-  name: boundless-operator-controller-manager
-  namespace: boundless-system
+  - kind: ServiceAccount
+    name: boundless-operator-controller-manager
+    namespace: boundless-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1052,9 +6047,9 @@ roleRef:
   kind: ClusterRole
   name: boundless-operator-manager-role
 subjects:
-- kind: ServiceAccount
-  name: boundless-operator-controller-manager
-  namespace: boundless-system
+  - kind: ServiceAccount
+    name: boundless-operator-controller-manager
+    namespace: boundless-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1072,9 +6067,9 @@ roleRef:
   kind: ClusterRole
   name: boundless-operator-proxy-role
 subjects:
-- kind: ServiceAccount
-  name: boundless-operator-controller-manager
-  namespace: boundless-system
+  - kind: ServiceAccount
+    name: boundless-operator-controller-manager
+    namespace: boundless-system
 ---
 apiVersion: v1
 kind: Service
@@ -1091,10 +6086,10 @@ metadata:
   namespace: boundless-system
 spec:
   ports:
-  - name: https
-    port: 8443
-    protocol: TCP
-    targetPort: https
+    - name: https
+      port: 8443
+      protocol: TCP
+      targetPort: https
   selector:
     control-plane: controller-manager
 ---
@@ -1127,78 +6122,77 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
-                - arm64
-                - ppc64le
-                - s390x
-              - key: kubernetes.io/os
-                operator: In
-                values:
-                - linux
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+                      - arm64
+                      - ppc64le
+                      - s390x
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
       containers:
-      - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
-        - --v=0
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: https
-          protocol: TCP
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 64Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-      - args:
-        - --health-probe-bind-address=:8081
-        - --metrics-bind-address=127.0.0.1:8080
-        - --leader-elect
-        command:
-        - /manager
-        env:
-        - name: ENABLE_WEBHOOKS
-          value: "false"
-        image: ghcr.io/mirantiscontainers/boundless-operator:1.0.0-rc1
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8081
-          initialDelaySeconds: 15
-          periodSeconds: 20
-        name: manager
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 8081
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 10m
-            memory: 64Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
+        - args:
+            - --secure-listen-address=0.0.0.0:8443
+            - --upstream=http://127.0.0.1:8080/
+            - --logtostderr=true
+            - --v=0
+          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+          name: kube-rbac-proxy
+          ports:
+            - containerPort: 8443
+              name: https
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 5m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+        - args:
+            - --health-probe-bind-address=:8081
+            - --metrics-bind-address=127.0.0.1:8080
+            - --leader-elect
+          command:
+            - /manager
+          image: ghcr.io/mirantiscontainers/boundless-operator:latest
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          name: manager
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: boundless-operator-controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
This PR updates the operator manifest to reflect the most recent changes in the operator. 

`resources.certManagement` are added under the blueprint specs for managing cert-manager resources