### PR TITLE
[no JIRA] k0s-libvirt single node example

### DIFF
--- a/terraform/k0s-libvirt/cloud_init.cfg
+++ b/terraform/k0s-libvirt/cloud_init.cfg
@@ -1,0 +1,10 @@
+#cloud-config
+ssh_pwauth: True
+
+users:
+  - name: ${user_account}
+    ssh_authorized_keys:
+      - ${public_key}
+    sudo: ['ALL=(ALL) NOPASSWD:ALL']
+    shell: /bin/bash
+    groups: wheel

--- a/terraform/k0s-libvirt/main.tf
+++ b/terraform/k0s-libvirt/main.tf
@@ -1,0 +1,101 @@
+terraform {
+  required_providers {
+    libvirt = {
+      source  = "dmacvicar/libvirt"
+    }
+  }
+}
+
+provider "libvirt" {
+  uri = "qemu:///system"
+}
+
+resource "libvirt_volume" "ubuntu-base" {
+  name   = "boundless-ubuntu-base.qcow2"
+  pool   = "default"
+  source = var.img_source
+  format = var.img_format
+}
+
+resource "libvirt_volume" "boundless_volume" {
+  name           = "${var.cluster_name}.${var.img_format}"
+  pool           = "default"
+  format         = var.img_format
+  size           = var.disk_size * 1000000000
+  base_volume_id = libvirt_volume.ubuntu-base.id
+}
+
+resource "libvirt_domain" "guest" {
+  name   = "${var.cluster_name}_ubuntu"
+  memory = var.mem_size
+  vcpu   = var.cores
+
+  disk {
+    volume_id = libvirt_volume.boundless_volume.id
+  }
+
+  network_interface {
+    network_name   = "default"
+    wait_for_lease = true
+  }
+
+  cloudinit = "${libvirt_cloudinit_disk.commoninit.id}"
+
+  console {
+    type        = "pty"
+    target_type = "serial"
+    target_port = "0"
+  }
+}
+
+resource "libvirt_cloudinit_disk" "commoninit" {
+  name      = "commoninit.iso"
+  user_data = data.template_file.user_data.rendered
+  pool      = "default"
+}
+
+data "template_file" "user_data" {
+  template = file("${path.module}/cloud_init.cfg")
+  vars = {
+    user_account = var.user_account
+    public_key   = var.ssh_public_key
+  }
+}
+
+locals {
+  k0s_tmpl = {
+    apiVersion = "boundless.mirantis.com/v1alpha1"
+    kind       = "Blueprint"
+    metadata = {
+      name = var.cluster_name
+    }
+    spec = {
+      kubernetes = {
+        provider = "k0s"
+        version = "1.30.0+k0s.0"
+        config = {
+        }
+        infra = {
+          hosts = [
+              {
+                  role = "single"
+                  ssh = {
+                      address = libvirt_domain.guest.network_interface[0].addresses[0]
+                      user = var.user_account
+                      keyPath = var.ssh_key_path
+                      port = 22
+                  }
+              }
+          ]
+        }
+      }
+      components = {
+        addons = []
+      }
+    }
+  }
+}
+
+output "k0s_cluster" {
+  value = yamlencode(local.k0s_tmpl)
+}

--- a/terraform/k0s-libvirt/terraform.tfvars.example
+++ b/terraform/k0s-libvirt/terraform.tfvars.example
@@ -1,0 +1,7 @@
+cluster_name = "boundless-cluster"
+cores = 2
+mem_size = "2048"
+disk_size = 20
+user_account = "user"
+ssh_public_key = "ssh-rsa AAAEXAMPLE user@example.com"
+ssh_key_path = "/home/user/.ssh/id_rsa"

--- a/terraform/k0s-libvirt/variables.tf
+++ b/terraform/k0s-libvirt/variables.tf
@@ -1,0 +1,52 @@
+variable "cluster_name" {
+  description = "Name of cluster"
+  type = string
+  default = "boundless"
+}
+
+variable "img_source" {
+  description = "Ubuntu 20.04 LTS Cloud Image"
+  default = "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64-disk-kvm.img"
+}
+
+variable "img_format" {
+  description = "QCow2 UEFI/GPT Bootable disk image"
+  type = string
+  default = "qcow2"
+}
+
+variable "mem_size" {
+  description = "Amount of RAM (in MiB) for the vm"
+  type        = string
+  default     = "2048"
+}
+
+variable "cores" {
+  description = "Number of CPU cores for the vm"
+  type        = number
+  default     = 2
+}
+
+variable "disk_size" {
+  description = "Amount of disk space (in GB) for the vm"
+  type        = number
+  default     = 20
+}
+
+variable user_account {
+  description = "User account name"
+  type = string
+  default = "user"
+}
+
+variable ssh_public_key {
+  description = "ssh public key for user account"
+  type = string
+  default = ""
+}
+
+variable ssh_key_path {
+  description = "Path of local ssh private key"
+  type = string
+  default = ""
+}

--- a/website/content/docs/getting-started/getting-started-with-k0s-and-libvirt.md
+++ b/website/content/docs/getting-started/getting-started-with-k0s-and-libvirt.md
@@ -1,0 +1,84 @@
+---
+title: "Getting Started with k0s and libvirt"
+draft: false
+weight: 4
+---
+
+This example shows how to create a single-node k0s cluster in a local VM using Terraform and libvirt. The boundless-operator may then be installed.
+
+#### Prerequisites
+
+Along with `boundless` CLI, you will also need the following tools installed:
+
+* [k0sctl](https://github.com/k0sproject/k0sctl#installation) - required for installing a k0s distribution
+* [terraform](https://www.terraform.io/) - for creating VMs
+* [libvirt](https://libvirt.org/) - required for running the local VM
+* [terraform-provider-libvirt](https://registry.terraform.io/providers/dmacvicar/libvirt) - required for provisioning libvirt VMs through terraform
+
+You will also need an SSH key for authentication with the created VM.
+
+#### Create virtual machines
+
+Creating virtual machines can be done using the [example Terraform scripts](https://github.com/mirantiscontainers/boundless/tree/main/terraform/k0s-libvirt).
+
+After copying the example TF scripts to your local machine, you can create the VMs with the following steps:
+
+1. Create a `terraform.tfvars` file with content similar to:
+```
+cluster_name = "boundless-cluster"
+cores = 2
+mem_size = "2048"
+disk_size = 20
+user_account = "user"
+ssh_public_key = "ssh-rsa AAAEXAMPLE user@example.com"
+ssh_key_path = "/home/user/.ssh/id_rsa"
+```
+2. `terraform init`
+3. `terraform plan`
+3. `terraform apply`
+4. `terraform output --raw k0s_cluster > cluster.yaml`
+
+> To get detailed information about the created VMs, you can use [virsh](https://www.libvirt.org/manpages/virsh.html):
+> ```
+> virsh machine list
+> ```
+
+#### Install Boundless Operator on `k0s`
+
+1. Verify or edit the blueprint created in the previous step, `cluster.yaml`
+
+2. Create the cluster:
+
+```shell
+bctl apply -f cluster.yaml
+```
+
+
+> Note: `bctl apply` adds kube config context to default location and sets it as the _current context_
+
+
+3. Update the cluster by modifying `cluster.yaml` and then running:
+```shell
+bctl update -f cluster.yaml
+```
+
+4. Monitor the status of the cluster's Kubernetes pods with:
+```
+watch -n 1 kubectl get pods --all-namespaces
+```
+
+#### Accessing the cluster
+
+The example app addon can now be accessed through the `http://<vm-node-ip>:6443` URL.
+
+#### Cleanup
+
+Delete the cluster:
+``` bash
+bctl reset -f cluster.yaml
+```
+
+Delete virtual machines by changing to the example TF folder and running:
+``` bash
+terraform destroy
+```


### PR DESCRIPTION
This PR adds an example for deploying a single-node cluster as a local VM using terraform and libvirt. In particular, I find this is faster and more stable than relying on AWS instances.

The restriction to a single node serves to keep this example simple and reflects the testing-focused usage where this deployment mode will be most useful. In my testing, deploying multi-node clusters works but requires an additional step of manually changing the hostname of each VM after applying the terraform script.