### PR TITLE
[NO JIRA] update bop manifest

### DIFF
--- a/deploy/static/boundless-operator.yaml
+++ b/deploy/static/boundless-operator.yaml
@@ -16,7 +16,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: addons.blueprint.mirantis.com
 spec:
   conversion:
@@ -177,8 +177,16 @@ spec:
                                       It matches with the resource annotations.
                                     type: string
                                   group:
+                                    description: |-
+                                      Group is the API group to select resources from.
+                                      Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
                                     type: string
                                   kind:
+                                    description: |-
+                                      Kind of the API Group to select resources from.
+                                      Together with Group and Version it is capable of unambiguously identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
                                     type: string
                                   labelSelector:
                                     description: |-
@@ -187,12 +195,16 @@ spec:
                                       It matches with the resource labels.
                                     type: string
                                   name:
-                                    description: Name of the resource.
+                                    description: Name to match resources with.
                                     type: string
                                   namespace:
-                                    description: Namespace the resource belongs to, if it can belong to a namespace.
+                                    description: Namespace to select resources from.
                                     type: string
                                   version:
+                                    description: |-
+                                      Version of the API Group to select resources from.
+                                      Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                      https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
                                     type: string
                                 type: object
                             required:
@@ -244,7 +256,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: blueprints.blueprint.mirantis.com
 spec:
   conversion:
@@ -407,8 +419,16 @@ spec:
                                                 It matches with the resource annotations.
                                               type: string
                                             group:
+                                              description: |-
+                                                Group is the API group to select resources from.
+                                                Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
                                               type: string
                                             kind:
+                                              description: |-
+                                                Kind of the API Group to select resources from.
+                                                Together with Group and Version it is capable of unambiguously identifying and/or selecting resources.
+                                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
                                               type: string
                                             labelSelector:
                                               description: |-
@@ -417,12 +437,16 @@ spec:
                                                 It matches with the resource labels.
                                               type: string
                                             name:
-                                              description: Name of the resource.
+                                              description: Name to match resources with.
                                               type: string
                                             namespace:
-                                              description: Namespace the resource belongs to, if it can belong to a namespace.
+                                              description: Namespace to select resources from.
                                               type: string
                                             version:
+                                              description: |-
+                                                Version of the API Group to select resources from.
+                                                Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                                https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
                                               type: string
                                           type: object
                                       required:
@@ -5470,7 +5494,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: installations.blueprint.mirantis.com
 spec:
   conversion:
@@ -5594,7 +5618,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.15.0
   name: manifests.blueprint.mirantis.com
 spec:
   conversion:
@@ -5745,8 +5769,16 @@ spec:
                                   It matches with the resource annotations.
                                 type: string
                               group:
+                                description: |-
+                                  Group is the API group to select resources from.
+                                  Together with Version and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                  https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
                                 type: string
                               kind:
+                                description: |-
+                                  Kind of the API Group to select resources from.
+                                  Together with Group and Version it is capable of unambiguously identifying and/or selecting resources.
+                                  https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
                                 type: string
                               labelSelector:
                                 description: |-
@@ -5755,12 +5787,16 @@ spec:
                                   It matches with the resource labels.
                                 type: string
                               name:
-                                description: Name of the resource.
+                                description: Name to match resources with.
                                 type: string
                               namespace:
-                                description: Namespace the resource belongs to, if it can belong to a namespace.
+                                description: Namespace to select resources from.
                                 type: string
                               version:
+                                description: |-
+                                  Version of the API Group to select resources from.
+                                  Together with Group and Kind it is capable of unambiguously identifying and/or selecting resources.
+                                  https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
                                 type: string
                             type: object
                         required:
@@ -6264,3 +6300,6 @@ spec:
           type: RuntimeDefault
       serviceAccountName: blueprint-operator-controller-manager
       terminationGracePeriodSeconds: 10
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master


### PR DESCRIPTION
While working on https://mirantis.jira.com/browse/BOP-1096, I found that the BOP manifest published in our docs is dated.

This PR updates the BOP manifest to the latest version https://github.com/MirantisContainers/blueprint-operator/blob/main/deploy/static/blueprint-operator.yaml